### PR TITLE
Enforce reading buffer as characters for browser readString

### DIFF
--- a/etc/browser/lib/files.js
+++ b/etc/browser/lib/files.js
@@ -23,7 +23,7 @@
     if (this.pos > buf.length) {
       return;
     }
-    return this.buf.slice(pos, pos + len).toString();
+    return String.fromCharCode.apply(null, this.buf.slice(pos, pos + len));
   };
 
   Tap.prototype.writeString = function (s) {

--- a/etc/browser/lib/files.js
+++ b/etc/browser/lib/files.js
@@ -23,7 +23,7 @@
     if (this.pos > buf.length) {
       return;
     }
-    return String.fromCharCode.apply(null, this.buf.slice(pos, pos + len));
+    return String.fromCharCode.apply(null, new Uint8Array(buf.buffer ? buf.buffer : buf, pos, len));
   };
 
   Tap.prototype.writeString = function (s) {


### PR DESCRIPTION
I was attempting to use avsc.decode on a WebSocket arraybuffer after reading other types before on the same buffer and instead of getting the string values I was getting "123,456,789".

This small change fixes this by ensuring the bytes are read as characters.