### PR TITLE
record type backward compability with default

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1834,7 +1834,7 @@ util.inherits(RecordType, Type);
 RecordType.prototype.fromBuffer = function (buf, resolver, noCheck) {
   var tap = new Tap(buf);
   var val = readValue(this, tap, resolver, noCheck);
-  let tapPos = tap.pos;
+  var tapPos = tap.pos;
   if (!tap.isValid()) {
     // Find the first field with default value which is only followed by fields with default values
     // or it's the last field in the Record

--- a/lib/types.js
+++ b/lib/types.js
@@ -1831,6 +1831,73 @@ function RecordType(attrs, opts) {
 }
 util.inherits(RecordType, Type);
 
+RecordType.prototype.fromBuffer = function (buf, resolver, noCheck) {
+  var tap = new Tap(buf);
+  var val = readValue(this, tap, resolver, noCheck);
+  let tapPos = tap.pos;
+  if (!tap.isValid()) {
+    // Find the first field with default value which is only followed by fields with default values
+    // or it's the last field in the Record
+    var firstDefaultIndex = this._fields.indexOf(this._fields.find(checkNextField.bind(this)));
+    
+    function checkNextField(field, index) {
+      if (field.getDefault() !== undefined) {
+        if (index == this._fields.length - 1) {
+          return true;
+        }
+        
+        var nextField = this._fields[index + 1];
+        return checkNextField.bind(this)(nextField, index + 1);
+      }
+      
+      return false;
+    }
+    
+    var validWithDefaults = false;
+    
+    if (firstDefaultIndex != -1) {
+      // Encode all default values after index and check if the buffer is valid
+      validWithDefaults = checkFields.bind(this)(firstDefaultIndex);
+      
+      function checkFields(index) {
+        var valid;
+        
+        var checkFields = this._fields.slice(index, this._fields.length);
+        var offset = 0;
+        
+        checkFields.map(function(c) {
+          c._type._write(tap, c.getDefault());
+        
+          offset += c._type.encode(c.getDefault(), buf, tap.pos);
+        });
+        
+        valid = tap.pos <= (-1 * offset) + tap.buf.length;
+        
+        if (!valid && index < this._fields.length - 1) {
+          checkFields.bind(this)(indexOfDefField);
+        }
+        
+        if (valid) {
+          // If it's valid set default values on the return object
+          checkFields.map(function(field) {
+            val[field._name] = field.getDefault();
+          });
+        }
+        
+        return valid;
+      }
+    }
+    
+    if (!validWithDefaults) {
+      throw new Error('truncated buffer');
+    }
+  }
+  if (!noCheck && tap.pos < buf.length) {
+    throw new Error('trailing data');
+  }
+  return val;
+};
+
 RecordType.prototype._getConstructorName = function () {
   return this._name ?
     unqualify(this._name) :

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -1767,6 +1767,63 @@ suite('types', function () {
       });
       assert.throws(function () { v2.createResolver(v1); });
     });
+    
+    test('RecordType.fromBuffer INSERT HERE', function() {
+      var v1 = createType({
+        type: 'record',
+        name: 'Person',
+        fields: [
+          {name: 'phone', type: 'string'}
+        ]
+      });
+      var v2 = createType({
+        type: 'record',
+        name: 'Person',
+        fields: [
+          {name: 'phone', type: 'string'},
+          {name: 'number', type: 'string'}
+        ]
+      });
+      
+      var msg = { phone: 'mobile' };
+      
+      var encoded = v1.toBuffer(msg);
+      
+      assert.throws(function () { v2.fromBuffer(encoded); });
+    });
+    
+    test('RecordType.fromBuffer with new schema with default values when encoded with old schema', function() {
+      var v1 = createType({
+        type: 'record',
+        name: 'Person',
+        fields: [
+          {name: 'phone', type: 'string'},
+          {name: 'number', type: 'string', default: '123'},
+          {name: 'make', type: 'string'}
+        ]
+      });
+      var v2 = createType({
+        type: 'record',
+        name: 'Person',
+        fields: [
+          {name: 'phone', type: 'string'},
+          {name: 'number', type: 'string', default: '123'},
+          {name: 'make', type: 'string'},
+          {name: 'work', type: 'boolean', default: true},
+          {name: 'model', type: 'string', default: '6s'},
+          {name: 'contacts', type: 'int', default: 11}
+        ]
+      });
+      
+      var msg = { phone: 'mobile', number: '546', make: 'Iphone' };
+      var expected = { phone: 'mobile', number: '546', make: 'Iphone', work: true, 'model': '6s', contacts: 11 };
+      
+      var encoded = v1.toBuffer(msg);
+      
+      var decoded = v2.fromBuffer(encoded);
+      
+      assert.deepEqual(decoded, expected);
+    });
 
     test('getName', function () {
       var t = createType({


### PR DESCRIPTION
The [avro specification about schema resolution](http://avro.apache.org/docs/1.8.1/spec.html#Schema+Resolution) says:
> if the reader's record schema has a field that contains a default value, and writer's schema does not have a field with the same name, then the reader should use the default value from its field.

More about this [here](http://docs.confluent.io/1.0.1/avro.html) with examples.

With the current version if I follow the examples from [above](http://docs.confluent.io/1.0.1/avro.html) I get a truncated buffer when calling `fromBuffer`.

Example with the current version:
```
'use strict';

const avro = require('avsc');

const schema1 = avro.parse({
    "namespace": "example.avro",
    "type": "record",
    "name": "user",
    "fields": [
        {
            "name": "name",
            "type": "string"
        },
        {
            "name": "favorite_number",
            "type": "int"
        }
    ]
});
const schema2 = avro.parse({
    "namespace": "example.avro",
    "type": "record",
    "name": "user",
    "fields": [
        {
            "name": "name",
            "type": "string"
        },
        {
            "name": "favorite_number",
            "type": "int"
        },
        {
            "name": "favorite_color",
            "type": "string",
            "default":  "green"
        },
        {
            "name": "happy",
            "type": "boolean",
            "default": true
        },
        {
            "name": "age",
            "type": "int",
            "default": 12
        },
        {
            "name": "data",
            "type": {
                "type": "map",
                "values": ["long", "string"]
            },
            "default": {
                "hah": 11111
            },
        }
    ]
});
const buf = schema1.toBuffer(message);

const val1 = schema1.fromBuffer(buf);
console.log(JSON.stringify(val1, 1, 2));

const val2 = schema2.fromBuffer(buf);
console.log(JSON.stringify(val2, 1, 2));

```

Examples with the changes:
```
'use strict';

const avro = require('avsc');

const schema1 = avro.parse({
    "namespace": "example.avro",
    "type": "record",
    "name": "user",
    "fields": [
        {
            "name": "name",
            "type": "string"
        },
        {
            "name": "favorite_number",
            "type": "int"
        }
    ]
});
const schema2 = avro.parse({
    "namespace": "example.avro",
    "type": "record",
    "name": "user",
    "fields": [
        {
            "name": "name",
            "type": "string"
        },
        {
            "name": "favorite_number",
            "type": "int"
        },
        {
            "name": "favorite_color",
            "type": "string",
            "default":  "green"
        },
        {
            "name": "happy",
            "type": "boolean",
            "default": true
        },
        {
            "name": "age",
            "type": "int",
            "default": 12
        },
        {
            "name": "data",
            "type": {
                "type": "map",
                "values": ["long", "string"]
            },
            "default": {
                "hah": 11111
            },
        }
    ]
});
const schema3 = avro.parse({
    "namespace": "example.avro",
    "type": "record",
    "name": "user",
    "fields": [
        {
            "name": "name",
            "type": "string"
        },
        {
            "name": "favorite_number",
            "type": "int"
        },
        {
            "name": "favorite_color",
            "type": "string",
            "default":  "green"
        },
        {
            "name": "happy",
            "type": "boolean"
        }
    ]
});

const message = {
    "name": "Joe",
    "favorite_number": 1
};

const buf = schema1.toBuffer(message);

const val1 = schema1.fromBuffer(buf);
console.log(JSON.stringify(val1, 1, 2));

const val2 = schema2.fromBuffer(buf);
console.log(JSON.stringify(val2, 1, 2));

try {
    schema3.fromBuffer(buf);
} catch(e) {
    console.log('expect to throw');
}
```