### PR TITLE
Patch: Don't try to copy a value if it doesn't exist

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -2115,6 +2115,7 @@ RecordType.prototype._checkFields = function (obj) {
 
 RecordType.prototype._copy = function (val, opts) {
   // jshint -W058
+  val = val || [];
   var hook = opts && opts.fieldHook;
   var values = [undefined];
   var i, l, field, value;

--- a/lib/types.js
+++ b/lib/types.js
@@ -2123,7 +2123,7 @@ RecordType.prototype._copy = function (val, opts) {
     value = val[field._name];
     if (value === undefined && field.hasOwnProperty('getDefault')) {
       value = field.getDefault();
-    } else if(val[field._name]) {
+    } else if(val[field._name] !== undefined) {
       value = field._type._copy(val[field._name], opts);
     }
     if (hook) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -2123,7 +2123,7 @@ RecordType.prototype._copy = function (val, opts) {
     value = val[field._name];
     if (value === undefined && field.hasOwnProperty('getDefault')) {
       value = field.getDefault();
-    } else {
+    } else if(val[field._name]) {
       value = field._type._copy(val[field._name], opts);
     }
     if (hook) {


### PR DESCRIPTION
When reproducing the solution described in [this stackoverflow issue](http://stackoverflow.com/questions/33236284/how-to-convert-a-json-object-into-avro-object-if-avro-schema-contains-union-in-i/33622239#33622239), I encountered a bug; specifically when my schema contains a child record — which my data does not contain (as it's meant to be optional)

The `type` I used to reproduce the bug:
```javascript
const type = avsc.parse(
	{
		'type':'record',
		'name':'DataFlowEntity_Level0',
		'fields': [
			{'name':'level0_null','type':['null','string', 'int']},
			{'name':'level0_string','type':['null','string', 'int']},
			{'name':'level0_int','type':['null','string', 'int']},
			{'name':'level0_boolean','type':['null','string', 'int', 'boolean']},
			{'name':'level0_record', type: [
				'null',
				{
					'type': 'record',
					'name': 'DataFlowEntity_Level1',
					'fields': [
						{'name':'level1_null','type':['null','string', 'int']},
						{'name':'level1_string','type':['null','string', 'int']},
						{'name':'level1_int','type':['null','string', 'int']},
						{'name':'level1_boolean','type':['null','string', 'int', 'boolean']},
					]
				}
			]}
		]
	},
	{
		wrapUnions: true
	}
);
```

The data for the test:
```javascript
const invalidRecord_withoutLevel1 = {
	'level0_null': null,
	'level0_string': 'example string',
	'level0_int': 123456,
	'level0_boolean': true,
};

const invalidRecord_withLevel1 = Object.assign({
	'level0_record': {
		'level1_null': null,
		'level1_string': 'example string',
		'level1_int': 123456,
		'level1_boolean': true,
	}
}, invalidRecord_withoutLevel1);
```

Running this code causes an error:
```javascript
const clonedRecord = type.clone(invalidRecord_withoutLevel1, { wrapUnions: true });
```

... which this PR attempts to patch in  in [avsc/lib/types.js](https://github.com/mtth/avsc/blob/master/lib/types.js#L2127). 

