### PR TITLE
call `Error.captureStackTrace` if possible

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -111,6 +111,7 @@ function Type(schema, opts) {
 Type.forSchema = function (schema, opts) {
   opts = opts || {};
   opts.registry = opts.registry || {};
+  opts.noStackTraces = opts.noStackTraces !== undefined ? opts.noStackTraces : false;
 
   var UnionType = (function (wrapUnions) {
     if (wrapUnions === true) {
@@ -2071,6 +2072,7 @@ function RecordType(schema, opts) {
   }, this));
   this._branchConstructor = this._createBranchConstructor();
   this._isError = schema.type === 'error';
+  this._noStackTraces = opts.noStackTraces;
   this.recordConstructor = this._createConstructor();
   this._read = this._createReader();
   this._skip = this._createSkipper();

--- a/lib/types.js
+++ b/lib/types.js
@@ -2092,31 +2092,42 @@ RecordType.prototype._createConstructor = function (errorStackTraces) {
   // jshint -W054
   var outerArgs = [];
   var innerArgs = [];
-  var errorStackTraces = errorStackTraces === undefined ? false : errorStackTraces;
   var ds = []; // Defaults.
   var innerBody = '';
-  var i, l, field, name, defaultValue;
+  var errorStackTraces = errorStackTraces === undefined ? false : errorStackTraces;
+  var i, l, field, name, getDefault, defaultValue;
   for (i = 0, l = this.fields.length; i < l; i++) {
     field = this.fields[i];
-    defaultValue = field.defaultValue;
+    getDefault = field.defaultValue;
+    defaultValue = getDefault();
     name = field.name;
     innerArgs.push('v' + i);
     innerBody += '  ';
-    if (defaultValue() === undefined) {
+
+    // Call Error.captureStackTrace only if record is of type error and has a
+    // a string "stack" field
+    // istanbul ignore else
+    if (defaultValue === undefined && this._isError && errorStackTraces &&
+        name === 'stack' && field.type instanceof StringType &&
+        typeof Error.captureStackTrace === 'function') {
+
+      defaultValue = true;
+      getDefault = function(ctx) {
+        // Error.captureStackTrace is only available in V8 environments
+        Error.captureStackTrace(ctx, ctx.constructor);
+        return ctx.stack;
+      };
+    }
+
+    if (defaultValue === undefined) {
       innerBody += 'this.' + name + ' = v' + i + ';\n';
     } else {
       innerBody += 'if (v' + i + ' === undefined) { ';
-      innerBody += 'this.' + name + ' = d' + ds.length + '(); ';
+      innerBody += 'this.' + name + ' = d' + ds.length + '(this); ';
       innerBody += '} else { this.' + name + ' = v' + i + '; }\n';
       outerArgs.push('d' + ds.length);
-      ds.push(defaultValue);
+      ds.push(getDefault);
     }
-  }
-  // istanbul ignore else
-  if (this._isError && errorStackTraces && typeof Error.captureStackTrace === 'function') {
-    // Error.captureStackTrace is only available in V8 environments
-    innerBody += '  if (this.stack === undefined) { ';
-    innerBody += 'Error.captureStackTrace(this, this.constructor); }\n';
   }
   var outerBody = 'return function ' + this._getConstructorName() + '(';
   outerBody += innerArgs.join() + ') {\n' + innerBody + '};';

--- a/lib/types.js
+++ b/lib/types.js
@@ -2094,6 +2094,10 @@ RecordType.prototype._createConstructor = function () {
   var innerArgs = [];
   var ds = []; // Defaults.
   var innerBody = '';
+  // `Error.captureStackTrace` is only available in V8 environments
+  if (this._isError && Error.captureStackTrace) {
+    innerBody = 'Error.captureStackTrace(this);\n';
+  }
   var i, l, field, name, defaultValue;
   for (i = 0, l = this.fields.length; i < l; i++) {
     field = this.fields[i];
@@ -2119,8 +2123,6 @@ RecordType.prototype._createConstructor = function () {
   Record.getType = function () { return self; };
   Record.type = self;
   if (this._isError) {
-    // Note that we aren't calling `Error.captureStackTrace` because this
-    // wouldn't be compatible with browsers other than Chrome.
     util.inherits(Record, Error);
     Record.prototype.name = this._getConstructorName();
   }

--- a/lib/types.js
+++ b/lib/types.js
@@ -111,9 +111,6 @@ function Type(schema, opts) {
 Type.forSchema = function (schema, opts) {
   opts = opts || {};
   opts.registry = opts.registry || {};
-  opts.errorStackTraces = opts.errorStackTraces !== undefined ?
-    opts.errorStackTraces :
-    false;
 
   var UnionType = (function (wrapUnions) {
     if (wrapUnions === true) {
@@ -2074,11 +2071,7 @@ function RecordType(schema, opts) {
   }, this));
   this._branchConstructor = this._createBranchConstructor();
   this._isError = schema.type === 'error';
-
-  // `Error.captureStackTrace` is only available in V8 environments
-  this._showStack = !opts.errorStackTraces && typeof Error.captureStackTrace === 'function';
-
-  this.recordConstructor = this._createConstructor();
+  this.recordConstructor = this._createConstructor(opts.errorStackTraces);
   this._read = this._createReader();
   this._skip = this._createSkipper();
   this._write = this._createWriter();
@@ -2095,10 +2088,11 @@ RecordType.prototype._getConstructorName = function () {
     this._isError ? 'Error$' : 'Record$';
 };
 
-RecordType.prototype._createConstructor = function () {
+RecordType.prototype._createConstructor = function (errorStackTraces) {
   // jshint -W054
   var outerArgs = [];
   var innerArgs = [];
+  var errorStackTraces = errorStackTraces === undefined ? false : errorStackTraces;
   var ds = []; // Defaults.
   var innerBody = '';
   var i, l, field, name, defaultValue;
@@ -2119,10 +2113,10 @@ RecordType.prototype._createConstructor = function () {
     }
   }
   // istanbul ignore else
-  if (this._isError && this._showStack) {
-    innerBody += 'if (!this.stack) {\n';
-    innerBody += '  Error.captureStackTrace(this, this.constructor);\n';
-    innerBody += '}';
+  if (this._isError && errorStackTraces && typeof Error.captureStackTrace === 'function') {
+    // Error.captureStackTrace is only available in V8 environments
+    innerBody += '  if (this.stack === undefined) { ';
+    innerBody += 'Error.captureStackTrace(this, this.constructor); }\n';
   }
   var outerBody = 'return function ' + this._getConstructorName() + '(';
   outerBody += innerArgs.join() + ') {\n' + innerBody + '};';

--- a/lib/types.js
+++ b/lib/types.js
@@ -111,7 +111,9 @@ function Type(schema, opts) {
 Type.forSchema = function (schema, opts) {
   opts = opts || {};
   opts.registry = opts.registry || {};
-  opts.noStackTraces = opts.noStackTraces !== undefined ? opts.noStackTraces : false;
+  opts.errorStackTraces = opts.errorStackTraces !== undefined ?
+    opts.errorStackTraces :
+    false;
 
   var UnionType = (function (wrapUnions) {
     if (wrapUnions === true) {
@@ -2074,7 +2076,7 @@ function RecordType(schema, opts) {
   this._isError = schema.type === 'error';
 
   // `Error.captureStackTrace` is only available in V8 environments
-  this._showStack = !opts.noStackTraces && typeof Error.captureStackTrace === 'function';
+  this._showStack = !opts.errorStackTraces && typeof Error.captureStackTrace === 'function';
 
   this.recordConstructor = this._createConstructor();
   this._read = this._createReader();

--- a/lib/types.js
+++ b/lib/types.js
@@ -2072,7 +2072,10 @@ function RecordType(schema, opts) {
   }, this));
   this._branchConstructor = this._createBranchConstructor();
   this._isError = schema.type === 'error';
-  this._noStackTraces = opts.noStackTraces;
+
+  // `Error.captureStackTrace` is only available in V8 environments
+  this._showStack = !opts.noStackTraces && typeof Error.captureStackTrace === 'function';
+
   this.recordConstructor = this._createConstructor();
   this._read = this._createReader();
   this._skip = this._createSkipper();
@@ -2096,10 +2099,6 @@ RecordType.prototype._createConstructor = function () {
   var innerArgs = [];
   var ds = []; // Defaults.
   var innerBody = '';
-  // `Error.captureStackTrace` is only available in V8 environments
-  if (this._isError && Error.captureStackTrace) {
-    innerBody = 'Error.captureStackTrace(this);\n';
-  }
   var i, l, field, name, defaultValue;
   for (i = 0, l = this.fields.length; i < l; i++) {
     field = this.fields[i];
@@ -2116,6 +2115,12 @@ RecordType.prototype._createConstructor = function () {
       outerArgs.push('d' + ds.length);
       ds.push(defaultValue);
     }
+  }
+  // istanbul ignore else
+  if (this._isError && this._showStack) {
+    innerBody += 'if (!this.stack) {\n';
+    innerBody += '  Error.captureStackTrace(this, this.constructor);\n';
+    innerBody += '}';
   }
   var outerBody = 'return function ' + this._getConstructorName() + '(';
   outerBody += innerArgs.join() + ') {\n' + innerBody + '};';

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -2144,14 +2144,14 @@ suite('types', function () {
         name: 'Ouch',
         fields: [
           {name: 'name', type: 'string'},
-          {name: 'stack', type: 'boolean'},
+          {name: 'stack', type: 'string'},
         ]
       }, {errorStackTraces: true});
 
       var E = t.getRecordConstructor();
-      var err = new E('MyError', false);
+      var err = new E('MyError', 'my amazing stack');
       assert(err instanceof Error);
-      assert(err.stack === false);
+      assert(err.stack === 'my amazing stack');
 
     });
 
@@ -2167,6 +2167,7 @@ suite('types', function () {
         name: 'Ouch',
         fields: [
           {name: 'name', type: 'string'},
+          {name: 'stack', type: 'string'},
         ]
       }, {errorStackTraces: true});
 
@@ -2174,6 +2175,7 @@ suite('types', function () {
       var err = new E('MyError');
       assert(err instanceof Error);
       assert(typeof err.stack === 'string');
+      assert(err.stack.indexOf('Ouch') === -1);
 
     });
 
@@ -2189,6 +2191,49 @@ suite('types', function () {
         name: 'Ouch',
         fields: [{name: 'name', type: 'string'}]
       });
+
+      var E = t.getRecordConstructor();
+      var err = new E('MyError');
+      assert(err instanceof Error);
+      assert(err.stack === undefined);
+
+    });
+
+    test('error type - stack is not populated if field is not defined', function() {
+
+      // This test only applies to V8 environments
+      if (typeof Error.captureStackTrace !== 'function') {
+        return;
+      }
+
+      var t = Type.forSchema({
+        type: 'error',
+        name: 'Ouch',
+        fields: [{name: 'name', type: 'string'}]
+      }, {errorStackTraces: true});
+
+      var E = t.getRecordConstructor();
+      var err = new E('MyError');
+      assert(err instanceof Error);
+      assert(err.stack === undefined);
+
+    });
+
+    test('error type - stack is not populated if field is not a string', function() {
+
+      // This test only applies to V8 environments
+      if (typeof Error.captureStackTrace !== 'function') {
+        return;
+      }
+
+      var t = Type.forSchema({
+        type: 'error',
+        name: 'Ouch',
+        fields: [
+          {name: 'name', type: 'string'},
+          {name: 'stack', type: 'boolean'},
+        ]
+      }, {errorStackTraces: true});
 
       var E = t.getRecordConstructor();
       var err = new E('MyError');

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -2783,6 +2783,26 @@ suite('types', function () {
       assert.throws(function () { Type.forSchema({type: 'b'}); });
     });
 
+    test('noStackTrace option', function() {
+      var type = Type.forSchema({
+        type: 'record',
+        name: 'Person',
+        fields: [{name: 'age', type: 'int'}]
+      }, {noStackTraces: true});
+
+      assert(type._noStackTraces);
+    });
+
+    test('noStackTrace default', function() {
+      var type = Type.forSchema({
+        type: 'record',
+        name: 'Person',
+        fields: [{name: 'age', type: 'int'}]
+      });
+
+      assert(!type._noStackTraces);
+    });
+
     test('namespaced type', function () {
       var type = Type.forSchema({
         type: 'record',

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -2173,7 +2173,7 @@ suite('types', function () {
       var E = t.getRecordConstructor();
       var err = new E('MyError');
       assert(err instanceof Error);
-      assert(err.stack);
+      assert(typeof err.stack === 'string');
 
     });
 

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -2130,6 +2130,7 @@ suite('types', function () {
       var E = t.getRecordConstructor();
       var err = new E('MyError');
       assert(err instanceof Error);
+      assert(err.stack, 'Error.captureStackTrace was not called');
     });
 
     test('anonymous error type', function () {


### PR DESCRIPTION
The constructors for schema defined errors now call `Error.captureStackTrace`
if it is available. As of today `Error.captureStackTrace` is only
available in V8 environments (nodejs & Chrome).