### PR TITLE
Windows compat: use path.sep instead of '/' in gereric parse().

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -168,10 +168,11 @@ function assembleProtocol(fpath, opts, cb) {
  *
  * The parsing logic is as follows:
  *
- * + If `str` contains a `/` and is a path to an existing file, it will first
- *   be read as JSON, then as an IDL specification if JSON parsing failed. If
- *   either succeeds, the result is returned, otherwise the next steps are run
- *   using the file's content instead of the input path.
+ * + If `str` contains `path.sep` (on windows `\`, otherwise `/`) and is a path
+ *   to an existing file, it will first be read as JSON, then as an IDL
+ *   specification if JSON parsing failed. If either succeeds, the result is
+ *   returned, otherwise the next steps are run using the file's content
+ *   instead of the input path.
  * + If `str` is a valid JSON string, it is parsed then returned.
  * + If `str` is a valid IDL protocol specification, it is parsed and returned
  *   if no imports are present (and an error is thrown if there are any
@@ -181,7 +182,7 @@ function assembleProtocol(fpath, opts, cb) {
  */
 function read(str) {
   var schema;
-  if (typeof str == 'string' && ~str.indexOf('/') && files.existsSync(str)) {
+  if (typeof str == 'string' && ~str.indexOf(path.sep) && files.existsSync(str)) {
     // Try interpreting `str` as path to a file contain a JSON schema or an IDL
     // protocol. Note that we add the second check to skip primitive references
     // (e.g. `"int"`, the most common use-case for `avro.parse`).


### PR DESCRIPTION
This gets the tests passing on windows, and should only affect people on that.

I'd think that regex checks would be better, since JSON and IDL are pretty unambiguous (though hardly trivial), but I suppose you *could* name a file `{"type": "fixed", "size": 100}` in Linux :)