### PR TITLE
use logical types in BlockDecoder

### DIFF
--- a/lib/containers.js
+++ b/lib/containers.js
@@ -137,7 +137,7 @@ function BlockDecoder(opts) {
   this._index = 0; // Next block index.
   this._needPush = false;
   this._finished = false;
-
+  this._logicalTypes = opts.logicalTypes;
   this.on('finish', function () {
     this._finished = true;
     if (this._needPush) {
@@ -185,7 +185,7 @@ BlockDecoder.prototype._decodeHeader = function () {
     if (this._parseHook) {
       schema = this._parseHook(schema);
     }
-    this._type = types.Type.forSchema(schema);
+    this._type = types.Type.forSchema(schema, { logicalTypes: this._logicalTypes });
   } catch (err) {
     this.emit('error', err);
     return;


### PR DESCRIPTION
PR for issue #105.
Adds test to BlockEncoder to use logical types.
Adds option in BlockEncoder to receive the logicalTypes.