### PR TITLE
Fixes string decoding when there's no native utf8Slice on the browser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,10 @@
 
 'use strict';
 
+var TextEncodingShim = require('text-encoding-shim');
+var TextDecoder = TextEncodingShim.TextDecoder;
+
+
 /** Various utilities used across this library. */
 
 var crypto = require('crypto');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -569,7 +569,7 @@ if (typeof Buffer.prototype.utf8Slice == 'function') {
     if (this.pos > buf.length) {
       return;
     }
-    return this.buf.slice(pos, pos + len).toString();
+    return (new TextDecoder("utf-8")).decode(buf.slice(pos, pos+len));
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avsc",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Avro for JavaScript",
   "homepage": "https://github.com/mtth/avsc",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/mtth/avsc.git"
+  },
+  "dependencies": {
+    "text-encoding-shim": "^1.0.0"
   }
 }


### PR DESCRIPTION
The patch uses a `TextDecoder` instance if there is no native `utf8Slice`.

I haven't managed to integrate my change in your system tests, because I haven't manage to run them.
The [issue](https://github.com/mtth/avsc/issues/116) has a testcase avro file that triggered the bug, and this patch no longer triggers it.
I've also included a polyfill dependency in case TextDecoder doesn't exist (Microsoft browsers).

If there's anything I can do to improve this, please let me know. I currently don't do any Javascript development so I'm not aware of the current process.

I've increased the minor version number, because this one is functionally different from the previous version.