### PR TITLE
resolved issue causing downstream writables not firing finish events …

### DIFF
--- a/lib/containers.js
+++ b/lib/containers.js
@@ -392,6 +392,11 @@ function BlockEncoder(schema, opts) {
     this._finished = true;
     if (this._blockCount) {
       this._flushChunk();
+    } else if (this._needPush) {
+        // if we finished but _needPush, we
+        // need to push null for downstream
+        // consumers
+        this.push(null);
     }
   });
 }


### PR DESCRIPTION
…if an empty stream is piped into a BlockEncoder. 

@mtth When piping an empty read stream to an avsc BlockEncoder (e.g. a stream that only pushes null), and then piping to a writeStream (like from fs.createWriteStream), listening to `finish` events on the writeStream or any of the stream instances in that chain is not possible. 

I'm not 100% certain that this change fits conceptually, but I know it solves this issue I'm experiencing. Would love to chat through it to make sure this makes sense. If you comment out my change and run the test, you should see the issue reproduced. 