### PR TITLE
Add more details to typescript annotation file, rearrange it.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,7 @@
 // TODO: Wherever the type is just `any`, it was probably generated automatically.
 //       Either finish documenting the type signature or document why `any` is appropriate.
 // TODO: Wherever the argument names are just `args: any`, it was probably generated from the signature of util.deprecate. Fix argument counts and types.
+// NOTE: This does not contain entries for functions available in the browser (functions/methods in etc/browser)
 
 import * as stream from 'stream';
 import { EventEmitter } from 'events'
@@ -39,7 +40,7 @@ export function assembleProtocol(filePath: string, opts: Partial<AssembleOptions
 export function assembleProtocol(filePath: string, callback: Callback<object>): void;
 export function combine(args: any): any;
 export function createFileDecoder(fileName: string, codecs?: Partial<CodecOptions>): Decoder;
-export function createFileEncoder(filePath: string, schema: any, options?: any): Encoder;
+export function createFileEncoder(filePath: string, schema: Schema, options?: any): Encoder;
 export function discoverProtocol(transport: Service.Transport, options: any, callback: Callback<any>): void;
 export function discoverProtocol(transport: Service.Transport, callback: Callback<any>): void;
 export function extractFileHeader(filePath: string, options?: any): void;
@@ -51,43 +52,42 @@ export function readSchema(schemaIdl: string, options?: Partial<ReaderOptions>):
 
 // TODO more specific types than `any`
 export class Type {
-  constructor(schema: any, opts: any);
   clone(val: any, opts?: any): any;
   compare(val1: any, val2: any): number;
   compareBuffers(buf1: any, buf2: any): number;
-  createResolver(type: any, opts?: any): any;
-  decode(buf: any, pos?: any, resolver?: any): any;
-  encode(val: any, buf: any, pos?: any): any;
-  equals(type: any): any;
+  constructor(schema: Schema, opts?: any);
+  createResolver(type: any, opts?: any): any;  // TODO: opts not documented on wiki
+  decode(buf: any, pos?: any, resolver?: any): any
   fingerprint(algorithm?: any): any;
+  fromBuffer(buffer: Buffer, resolver?: any, noCheck?: boolean): Type; // TODO
   fromString(str: any): any;
-  readonly aliases: any;
-  readonly name: string|undefined;
-  readonly branchName: string|undefined;
-  readonly typeName: string;
   inspect(): string;
   isValid(val: any, opts?: any): any;
   random(): Type;
   schema(opts?: any): any;
+  toBuffer(value: object): Buffer;
   toJSON(): string;
   toString(val?: any): any;
   wrap(val: any): any;
-  fromBuffer(buffer: Buffer, resolver: any, noCheck: boolean): Type; // TODO
-  toBuffer(value: object): Buffer;
+  readonly aliases: string[]|undefined;
+  readonly doc: string|undefined;
+  readonly name: string|undefined;
+  readonly branchName: string|undefined;
+  readonly typeName: string;
   static forSchema(schema: Schema, opts?: any): Type;
   static forTypes(types: any, opts?: any): Type;
   static forValue(value: object, opts?: any): Type;
-  static isType(arg: any): boolean;  // TODO remaining args
+  static isType(arg: any, ...prefix: string[]): boolean;
+  static __reset(size: number): void;
 }
 
-// TODO: Can this project remove Protocol from types completely, it's a deprecated export?
+// Deprecated, but kept for now because this is referenced elsewhere (e.g. Service.forProtocol())
 export class Protocol {
   constructor(name: any, messages: any, types: any, ptcl: any, server: any);
   createClient(opts: any): any;
   createEmitter(args: any): any;
   createListener(args: any): any;
   createServer(opts: any): any;
-  emit(args: any): any;
   equals(args: any): any;
   getMessage(args: any): any;
   getMessages(args: any): any;
@@ -97,8 +97,6 @@ export class Protocol {
   getTypes(args: any): any;
   inspect(): string;
   message(name: any): any;
-  on(args: any): any;
-  subprotocol(args: any): any;
   type(name: any): any;
   static compatible(clientSvc: any, serverSvc: any): any;
   static forProtocol(ptcl: any, opts: any): any;
@@ -108,19 +106,18 @@ export class Protocol {
 export class Service {
   constructor(name: any, messages: any, types: any, ptcl: any, server: any);
   createClient(options?: Partial<Service.ClientOptions>): Service.Client;
-  createEmitter(args: any): any;
-  createListener(args: any): any;
   createServer(options?: Partial<Service.ServerOptions>): Service.Server;
-  emit(args: any): any;
   equals(args: any): any;  // deprecated
-  readonly hash: Buffer;
-  readonly protocol: any;
   inspect(): string;
   message(name: string): any;
-  on(args: any): any;
-  subprotocol(args: any): any;
-  type(name: string): any;
+  type(name: string): Type|undefined;
 
+  readonly doc: string|undefined;
+  readonly hash: Buffer;
+  readonly messages: any[];
+  readonly name: string;
+  readonly protocol: any;
+  readonly types: Type[];
 
   static compatible(client: Service.Client, server: Service.Server): boolean;
   static forProtocol(protocol: Protocol, options: any): Service;
@@ -130,20 +127,20 @@ export class Service {
 export namespace Service {
   interface ClientChannel extends EventEmitter {
     readonly client: Client;
-    readonly timeout: number;
     readonly destroyed: boolean;
     readonly draining: boolean;
     readonly pending: number;
-    ping(timeout: number, cb: any): void;
-    destroy(noWait: boolean): void;
+    readonly timeout: number;
+    ping(timeout?: number, cb?: any): void;
+    destroy(noWait?: boolean): void;
   }
 
   interface ServerChannel extends EventEmitter  {
-    readonly server: Server;
     readonly destroyed: boolean;
     readonly draining: boolean;
     readonly pending: number;
-    destroy(noWait: boolean): void;
+    readonly server: Server;
+    destroy(noWait?: boolean): void;
   }
 
   interface ClientOptions {
@@ -196,54 +193,54 @@ export namespace Service {
 
 export namespace streams {
   class BlockDecoder {
-    constructor(opts: any);
+    constructor(opts?: any);
     static defaultCodecs(): any;
   }
 
   class BlockEncoder {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts: any);
     static defaultCodecs(): any;
   }
 
   class RawDecoder {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts: any);
   }
 
   class RawEncoder {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts: any);
   }
 }
 
 export namespace types {
   class ArrayType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts: any);
     readonly itemsType: Type;
     random(): ArrayType;
   }
 
-  class BooleanType extends Type {
+  class BooleanType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): BooleanType;
   }
 
-  class BytesType extends Type {
+  class BytesType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): BytesType;
   }
 
-  class DoubleType extends Type {
+  class DoubleType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): DoubleType;
   }
 
   class EnumType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts?: any);
     readonly symbols: string[];
     random(): EnumType;
   }
 
   class FixedType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts?: any);
     readonly size: number;
     random(): FixedType;
   }
@@ -259,47 +256,60 @@ export namespace types {
   }
 
   class LogicalType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts?: any);
     readonly underlyingType: Type;
+    _export(schema: Schema): void;
+    _fromValue(val: any): any;
+    _resolve(type: Type): any;
+    _toValue(any: any): any;
     random(): LogicalType;
   }
 
   class LongType extends Type {
     constructor();
     random(): LongType;
+    __with(methods: object, noUnpack?: boolean;
   }
 
   class MapType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts?: any);
     readonly valuesType: any;
     random(): MapType;
   }
 
-  class NullType extends Type {
+  class NullType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): NullType;
   }
 
   class RecordType extends Type {
-    constructor(schema: any, opts: any);
-    field(name: any): any;
-    readonly fields: any[];  // TODO: Field[] once Field interface/class exists
+    constructor(schema: Schema, opts?: any);
+    readonly fields: Field[];
     readonly recordConstructor: any;  // TODO: typeof Record once Record interface/class exists
+    field(name: string): Field;
     random(): RecordType;
   }
 
-  class StringType extends Type {
+  class Field {
+    aliases: string[];
+    defaultValue(): any;
+    name: string;
+    order: string;
+    type: Type;
+  }
+
+  class StringType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): StringType;
   }
 
   class UnwrappedUnionType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts: any);
     random(): UnwrappedUnionType;
   }
 
   class WrappedUnionType extends Type {
-    constructor(schema: any, opts: any);
+    constructor(schema: Schema, opts: any);
     random(): WrappedUnionType;
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,6 @@
 // Note: this typing file is incomplete (https://github.com/mtth/avsc/pull/134).
+// TODO: Wherever the type is just `any`, it was probably generated automatically.
+//       Either finish documenting the type signature or document why `any` is appropriate.
 
 import * as stream from 'stream';
 import { EventEmitter } from 'events'
@@ -15,7 +17,7 @@ export interface CodecOptions {
 }
 
 export interface Decoder {
-  on(type: 'metadata', callback: (type: Type.Type) => void): this;
+  on(type: 'metadata', callback: (type: Type) => void): this;
   on(type: 'data', callback: (value: object) => void): this;
 }
 
@@ -31,52 +33,121 @@ interface AssembleOptions {
   importHook: (filePath: string, type: 'idl', callback: Callback<object>) => void;
 }
 
+export function assemble(args: any): any;
 export function assembleProtocol(filePath: string, opts: Partial<AssembleOptions>, callback: Callback<object>): void;
 export function assembleProtocol(filePath: string, callback: Callback<object>): void;
+export function combine(args: any): any;
 export function createFileDecoder(fileName: string, codecs?: Partial<CodecOptions>): Decoder;
 export function createFileEncoder(filePath: string, schema: any, options?: any): Encoder;
 export function discoverProtocol(transport: Service.Transport, options: any, callback: Callback<any>): void;
 export function discoverProtocol(transport: Service.Transport, callback: Callback<any>): void;
 export function extractFileHeader(filePath: string, options?: any): void;
-export function parse(schemaOrProtocolIdl: string, options?: any): Service.Protocol | Type.Type; // TODO
-export function readProtocol(protocolIdl: string, options?: Partial<ReaderOptions>): Service.Protocol;
+export function infer(args: any): any;
+export function parse(schemaOrProtocolIdl: string, options?: any): Protocol | Type; // TODO
+export function readProtocol(protocolIdl: string, options?: Partial<ReaderOptions>): Protocol;
 export function readSchema(schemaIdl: string, options?: Partial<ReaderOptions>): Schema;
 // TODO streams
+
 // TODO types
+export class Type {
+  constructor(schema: any, opts: any);
+  clone(val: any, opts?: any): any;
+  compare(val1: any, val2: any): number;
+  compareBuffers(buf1: any, buf2: any): number;
+  createResolver(type: any, opts?: any): any;
+  decode(buf: any, pos?: any, resolver?: any): any;
+  encode(val: any, buf: any, pos?: any): any;
+  equals(type: any): any;
+  fingerprint(algorithm?: any): any;
+  fromString(str: any): any;
+  getAliases(): any;
+  getFingerprint(algorithm?: any): any;
+  getName(asBranch: any): any;
+  getSchema(opts: any): any;
+  getTypeName(): any;
+  inspect(): any;
+  isValid(val: any, opts?: any): any;
+  random(): Type;
+  schema(opts?: any): any;
+  toJSON(): any;
+  toString(val?: any): any;
+  wrap(val: any): any;
+  // TODO clone(val, opts)
+  // TODO compare
+  // TODO compareBuffers(buf1, buf2)
+  // TODO createResolver(type, opts)
+  // TODO decode(buf, pos, resolver)
+  // TODO encode(val, buf, pos)
+  // TODO equals(type)
+  // TODO fingerprint(algorithm)
+  fromBuffer(buffer: Buffer, resolver: any, noCheck: boolean): Type; // TODO
+  // TODO fromString(str)
+  // TODO inspect()
+  // TODO isValid(val, opts)
+  toBuffer(value: object): Buffer;
+  // TODO toJSON()
+  // TODO toString(val)
+  // TODO wrap(val)
+  //
+  static forSchema(schema: Schema, opts?: any): Type;
+  static forTypes(types: any, opts?: any): Type;
+  static forValue(value: object, opts?: any): Type;
+  static isType(arg: any): boolean;  // TODO remaining args
+}
 
-export namespace Type {
-  interface Type {
-    // TODO clone(val, opts)
-    // TODO compare
-    // TODO compareBuffers(buf1, buf2)
-    // TODO createResolver(type, opts)
-    // TODO decode(buf, pos, resolver)
-    // TODO encode(val, buf, pos)
-    // TODO equals(type)
-    // TODO fingerprint(algorithm)
-    fromBuffer(buffer: Buffer, resolver: any, noCheck: boolean): Type; // TODO
-    // TODO fromString(str)
-    // TODO inspect()
-    // TODO isValid(val, opts)
-    // TODO random()
-    // TODO schema(opts)
-    toBuffer(value: object): Buffer;
-    // TODO toJSON()
-    // TODO toString(val)
-    // TODO wrap(val)
-  }
+export class Protocol {
+  constructor(name: any, messages: any, types: any, ptcl: any, server: any);
+  createClient(opts: any): any;
+  createEmitter(args: any): any;
+  createListener(args: any): any;
+  createServer(opts: any): any;
+  emit(args: any): any;
+  equals(args: any): any;
+  getFingerprint(args: any): any;
+  getMessage(args: any): any;
+  getMessages(args: any): any;
+  getName(args: any): any;
+  getSchema(args: any): any;
+  getType(args: any): any;
+  getTypes(args: any): any;
+  inspect(): any;
+  message(name: any): any;
+  on(args: any): any;
+  subprotocol(args: any): any;
+  type(name: any): any;
+  static compatible(clientSvc: any, serverSvc: any): any;
+  static forProtocol(ptcl: any, opts: any): any;
+  static isService(any: any): any;
+}
 
-  function forSchema(schema: Schema): Type;
-  function forValue(value: object): Type;
-  // TODO function forTypes(types, opts)
-  function isType(arg: any): boolean; // TODO
+export class Service {
+  constructor(name: any, messages: any, types: any, ptcl: any, server: any);
+  createClient(options?: Partial<Service.ClientOptions>): Service.Client;
+  createEmitter(args: any): any;
+  createListener(args: any): any;
+  createServer(options?: Partial<Service.ServerOptions>): Service.Server;
+  emit(args: any): any;
+  equals(args: any): any;
+  getFingerprint(args: any): any;
+  getMessage(args: any): any;
+  getMessages(args: any): any;
+  getName(args: any): any;
+  getSchema(args: any): any;
+  getType(args: any): any;
+  getTypes(args: any): any;
+  inspect(): any;
+  message(name: string): any;
+  on(args: any): any;
+  subprotocol(args: any): any;
+  type(name: string): any;
+
+
+  static compatible(client: Service.Client, server: Service.Server): boolean;
+  static forProtocol(protocol: Protocol, options: any): Service;
+  static isService(obj: any): boolean;
 }
 
 export namespace Service {
-  interface Protocol {
-    [key: string]: any; // TODO object should be further specified
-  }
-
   interface ClientChannel extends EventEmitter {
     readonly client: Client;
     readonly timeout: number;
@@ -107,13 +178,6 @@ export namespace Service {
     objectMode: boolean;
   }
 
-  interface Service {
-    createClient(options?: Partial<ClientOptions>): Client;
-    createServer(options?: Partial<ServerOptions>): Server;
-    message(name: string): any;
-    type(name: string): any;
-  }
-
   type TransportFunction = () => void; // TODO
 
   type Transport = stream.Duplex | TransportFunction;
@@ -126,9 +190,12 @@ export namespace Service {
     noWait: boolean;
   }
 
-  interface Server extends EventEmitter {
+  class Server extends EventEmitter {
+    constructor(svc: any, opts: any);
+
     readonly service: Service;
     // on<message>()
+
     activeChannels(): ServerChannel[];
     createChannel(transport: Transport, options?: Partial<ChannelCreateOptions>): ServerChannel;
     onMessage<T>(name: string, handler: (arg1: any, callback: Callback<T>) => void): this;
@@ -136,7 +203,8 @@ export namespace Service {
     use(...args: any[]): this;
   }
 
-  interface Client extends EventEmitter {
+  class Client extends EventEmitter {
+    constructor(svc: any, opts: any);
     activeChannels(): ClientChannel[];
     createChannel(transport: Transport, options?: Partial<ChannelCreateOptions>): ClientChannel;
     destroyChannels(options?: Partial<ChannelDestroyOptions>): void;
@@ -144,8 +212,117 @@ export namespace Service {
     remoteProtocols(): Protocol[];
     use(...args: any[]): this;
   }
+}
 
-  function compatible(client: Client, server: Server): boolean;
-  function forProtocol(protocol: Protocol, options: any): Service;
-  function isService(obj: any): boolean;
+export namespace streams {
+  class BlockDecoder {
+    constructor(opts: any);
+    static defaultCodecs(): any;
+    static getDefaultCodecs(): any;
+  }
+
+  class BlockEncoder {
+    constructor(schema: any, opts: any);
+    static defaultCodecs(): any;
+    static getDefaultCodecs(): any;
+  }
+
+  class RawDecoder {
+    constructor(schema: any, opts: any);
+  }
+
+  class RawEncoder {
+    constructor(schema: any, opts: any);
+  }
+}
+
+export namespace types {
+  class ArrayType extends Type {
+    constructor(schema: any, opts: any);
+    getItemsType(): any;
+    random(): ArrayType;
+  }
+
+  class BooleanType extends Type {
+    constructor();
+    random(): BooleanType;
+  }
+
+  class BytesType extends Type {
+    constructor();
+    random(): BytesType;
+  }
+
+  class DoubleType extends Type {
+    constructor();
+    random(): DoubleType;
+  }
+
+  class EnumType extends Type {
+    constructor(schema: any, opts: any);
+    getSymbols(): any;
+    random(): EnumType;
+  }
+
+  class FixedType extends Type {
+    constructor(schema: any, opts: any);
+    getSize(): any;
+    random(): FixedType;
+  }
+
+  class FloatType extends Type {
+    constructor();
+    random(): FloatType;
+  }
+
+  class IntType extends Type {
+    constructor();
+    random(): IntType;
+  }
+
+  class LogicalType extends Type {
+    constructor(schema: any, opts: any);
+    getUnderlyingType(): any;
+    random(): LogicalType;
+  }
+
+  class LongType extends Type {
+    constructor();
+    random(): LongType;
+  }
+
+  class MapType extends Type {
+    constructor(schema: any, opts: any);
+    getValuesType(): any;
+    random(): MapType;
+  }
+
+  class NullType extends Type {
+    constructor();
+    random(): NullType;
+  }
+
+  class RecordType extends Type {
+    constructor(schema: any, opts: any);
+    field(name: any): any;
+    getField(name: any): any;
+    getFields(): any;
+    getRecordConstructor(): any;
+    random(): RecordType;
+  }
+
+  class StringType extends Type {
+    constructor();
+    random(): StringType;
+  }
+
+  class UnwrappedUnionType extends Type {
+    constructor(schema: any, opts: any);
+    random(): UnwrappedUnionType;
+  }
+
+  class WrappedUnionType extends Type {
+    constructor(schema: any, opts: any);
+    random(): WrappedUnionType;
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,8 +45,8 @@ export function discoverProtocol(transport: Service.Transport, options: any, cal
 export function discoverProtocol(transport: Service.Transport, callback: Callback<any>): void;
 export function extractFileHeader(filePath: string, options?: any): void;
 export function infer(args: any): any;
-export function parse(schemaOrProtocolIdl: string, options?: any): Protocol | Type; // TODO
-export function readProtocol(protocolIdl: string, options?: Partial<ReaderOptions>): Protocol;
+export function parse(schemaOrProtocolIdl: string, options?: any): any; // TODO protocol literal or Type
+export function readProtocol(protocolIdl: string, options?: Partial<ReaderOptions>): any;
 export function readSchema(schemaIdl: string, options?: Partial<ReaderOptions>): Schema;
 // TODO streams
 
@@ -81,28 +81,6 @@ export class Type {
   static __reset(size: number): void;
 }
 
-// Deprecated, but kept for now because this is referenced elsewhere (e.g. Service.forProtocol())
-export class Protocol {
-  constructor(name: any, messages: any, types: any, ptcl: any, server: any);
-  createClient(opts?: object): Client;
-  createEmitter(args: any): any;
-  createListener(args: any): any;
-  createServer(opts: any): any;
-  equals(args: any): any;
-  getMessage(args: any): any;
-  getMessages(args: any): any;
-  getName(args: any): any;
-  getSchema(args: any): any;
-  getType(args: any): any;
-  getTypes(args: any): any;
-  inspect(): string;
-  message(name: any): any;
-  type(name: any): any;
-  static compatible(clientSvc: any, serverSvc: any): any;
-  static forProtocol(protocol: Protocol, opts?: any): any;
-  static isService(any: any): any;
-}
-
 export class Service {
   constructor(name: any, messages: any, types: any, ptcl: any, server: any);
   createClient(options?: Partial<Service.ClientOptions>): Service.Client;
@@ -120,7 +98,7 @@ export class Service {
   readonly types: Type[];
 
   static compatible(client: Service.Client, server: Service.Server): boolean;
-  static forProtocol(protocol: Protocol, options: any): Service;
+  static forProtocol(protocol: any, options: any): Service;
   static isService(obj: any): boolean;
 }
 
@@ -176,7 +154,7 @@ export namespace Service {
     activeChannels(): ServerChannel[];
     createChannel(transport: Transport, options?: Partial<ChannelCreateOptions>): ServerChannel;
     onMessage<T>(name: string, handler: (arg1: any, callback: Callback<T>) => void): this;
-    remoteProtocols(): Protocol[];
+    remoteProtocols(): any[];
     use(...args: any[]): this;
   }
 
@@ -186,7 +164,7 @@ export namespace Service {
     createChannel(transport: Transport, options?: Partial<ChannelCreateOptions>): ClientChannel;
     destroyChannels(options?: Partial<ChannelDestroyOptions>): void;
     emitMessage<T>(name: string, req: any, options?: any, callback?: Callback<T>): void // TODO
-    remoteProtocols(): Protocol[];
+    remoteProtocols(): any[];
     use(...args: any[]): this;
   }
 }
@@ -268,7 +246,7 @@ export namespace types {
   class LongType extends Type {
     constructor();
     random(): LongType;
-    __with(methods: object, noUnpack?: boolean;
+    static __with(methods: object, noUnpack?: boolean) : void;
   }
 
   class MapType extends Type {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 // Note: this typing file is incomplete (https://github.com/mtth/avsc/pull/134).
 // TODO: Wherever the type is just `any`, it was probably generated automatically.
 //       Either finish documenting the type signature or document why `any` is appropriate.
+// TODO: Wherever the argument names are just `args: any`, it was probably generated from the signature of util.deprecate. Fix argument counts and types.
 
 import * as stream from 'stream';
 import { EventEmitter } from 'events'
@@ -48,7 +49,7 @@ export function readProtocol(protocolIdl: string, options?: Partial<ReaderOption
 export function readSchema(schemaIdl: string, options?: Partial<ReaderOptions>): Schema;
 // TODO streams
 
-// TODO types
+// TODO more specific types than `any`
 export class Type {
   constructor(schema: any, opts: any);
   clone(val: any, opts?: any): any;
@@ -64,37 +65,22 @@ export class Type {
   readonly name: string|undefined;
   readonly branchName: string|undefined;
   readonly typeName: string;
-  inspect(): any;
+  inspect(): string;
   isValid(val: any, opts?: any): any;
   random(): Type;
   schema(opts?: any): any;
-  toJSON(): any;
+  toJSON(): string;
   toString(val?: any): any;
   wrap(val: any): any;
-  // TODO clone(val, opts)
-  // TODO compare
-  // TODO compareBuffers(buf1, buf2)
-  // TODO createResolver(type, opts)
-  // TODO decode(buf, pos, resolver)
-  // TODO encode(val, buf, pos)
-  // TODO equals(type)
-  // TODO fingerprint(algorithm)
   fromBuffer(buffer: Buffer, resolver: any, noCheck: boolean): Type; // TODO
-  // TODO fromString(str)
-  // TODO inspect()
-  // TODO isValid(val, opts)
   toBuffer(value: object): Buffer;
-  // TODO toJSON()
-  // TODO toString(val)
-  // TODO wrap(val)
-  //
   static forSchema(schema: Schema, opts?: any): Type;
   static forTypes(types: any, opts?: any): Type;
   static forValue(value: object, opts?: any): Type;
   static isType(arg: any): boolean;  // TODO remaining args
 }
 
-// TODO: Remove this class from types, it's deprecated?
+// TODO: Can this project remove Protocol from types completely, it's a deprecated export?
 export class Protocol {
   constructor(name: any, messages: any, types: any, ptcl: any, server: any);
   createClient(opts: any): any;
@@ -109,7 +95,7 @@ export class Protocol {
   getSchema(args: any): any;
   getType(args: any): any;
   getTypes(args: any): any;
-  inspect(): any;
+  inspect(): string;
   message(name: any): any;
   on(args: any): any;
   subprotocol(args: any): any;
@@ -129,7 +115,7 @@ export class Service {
   equals(args: any): any;  // deprecated
   readonly hash: Buffer;
   readonly protocol: any;
-  inspect(): any;
+  inspect(): string;
   message(name: string): any;
   on(args: any): any;
   subprotocol(args: any): any;
@@ -297,8 +283,8 @@ export namespace types {
   class RecordType extends Type {
     constructor(schema: any, opts: any);
     field(name: any): any;
-    readonly fields: any[];  // TODO: Field[]
-    readonly recordConstructor: any;  // TODO: typeof Record
+    readonly fields: any[];  // TODO: Field[] once Field interface/class exists
+    readonly recordConstructor: any;  // TODO: typeof Record once Record interface/class exists
     random(): RecordType;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,11 +60,10 @@ export class Type {
   equals(type: any): any;
   fingerprint(algorithm?: any): any;
   fromString(str: any): any;
-  getAliases(): any;
-  getFingerprint(algorithm?: any): any;
-  getName(asBranch: any): any;
-  getSchema(opts: any): any;
-  getTypeName(): any;
+  readonly aliases: any;
+  readonly name: string|undefined;
+  readonly branchName: string|undefined;
+  readonly typeName: string;
   inspect(): any;
   isValid(val: any, opts?: any): any;
   random(): Type;
@@ -95,6 +94,7 @@ export class Type {
   static isType(arg: any): boolean;  // TODO remaining args
 }
 
+// TODO: Remove this class from types, it's deprecated?
 export class Protocol {
   constructor(name: any, messages: any, types: any, ptcl: any, server: any);
   createClient(opts: any): any;
@@ -103,7 +103,6 @@ export class Protocol {
   createServer(opts: any): any;
   emit(args: any): any;
   equals(args: any): any;
-  getFingerprint(args: any): any;
   getMessage(args: any): any;
   getMessages(args: any): any;
   getName(args: any): any;
@@ -127,14 +126,9 @@ export class Service {
   createListener(args: any): any;
   createServer(options?: Partial<Service.ServerOptions>): Service.Server;
   emit(args: any): any;
-  equals(args: any): any;
-  getFingerprint(args: any): any;
-  getMessage(args: any): any;
-  getMessages(args: any): any;
-  getName(args: any): any;
-  getSchema(args: any): any;
-  getType(args: any): any;
-  getTypes(args: any): any;
+  equals(args: any): any;  // deprecated
+  readonly hash: Buffer;
+  readonly protocol: any;
   inspect(): any;
   message(name: string): any;
   on(args: any): any;
@@ -218,13 +212,11 @@ export namespace streams {
   class BlockDecoder {
     constructor(opts: any);
     static defaultCodecs(): any;
-    static getDefaultCodecs(): any;
   }
 
   class BlockEncoder {
     constructor(schema: any, opts: any);
     static defaultCodecs(): any;
-    static getDefaultCodecs(): any;
   }
 
   class RawDecoder {
@@ -239,7 +231,7 @@ export namespace streams {
 export namespace types {
   class ArrayType extends Type {
     constructor(schema: any, opts: any);
-    getItemsType(): any;
+    readonly itemsType: Type;
     random(): ArrayType;
   }
 
@@ -260,13 +252,13 @@ export namespace types {
 
   class EnumType extends Type {
     constructor(schema: any, opts: any);
-    getSymbols(): any;
+    readonly symbols: string[];
     random(): EnumType;
   }
 
   class FixedType extends Type {
     constructor(schema: any, opts: any);
-    getSize(): any;
+    readonly size: number;
     random(): FixedType;
   }
 
@@ -282,7 +274,7 @@ export namespace types {
 
   class LogicalType extends Type {
     constructor(schema: any, opts: any);
-    getUnderlyingType(): any;
+    readonly underlyingType: Type;
     random(): LogicalType;
   }
 
@@ -293,7 +285,7 @@ export namespace types {
 
   class MapType extends Type {
     constructor(schema: any, opts: any);
-    getValuesType(): any;
+    readonly valuesType: any;
     random(): MapType;
   }
 
@@ -305,9 +297,8 @@ export namespace types {
   class RecordType extends Type {
     constructor(schema: any, opts: any);
     field(name: any): any;
-    getField(name: any): any;
-    getFields(): any;
-    getRecordConstructor(): any;
+    readonly fields: any[];  // TODO: Field[]
+    readonly recordConstructor: any;  // TODO: typeof Record
     random(): RecordType;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,7 +84,7 @@ export class Type {
 // Deprecated, but kept for now because this is referenced elsewhere (e.g. Service.forProtocol())
 export class Protocol {
   constructor(name: any, messages: any, types: any, ptcl: any, server: any);
-  createClient(opts: any): any;
+  createClient(opts?: object): Client;
   createEmitter(args: any): any;
   createListener(args: any): any;
   createServer(opts: any): any;
@@ -99,7 +99,7 @@ export class Protocol {
   message(name: any): any;
   type(name: any): any;
   static compatible(clientSvc: any, serverSvc: any): any;
-  static forProtocol(ptcl: any, opts: any): any;
+  static forProtocol(protocol: Protocol, opts?: any): any;
   static isService(any: any): any;
 }
 


### PR DESCRIPTION
Many of the types were generated by (a patched version of) dts-gen.
Because of that, many methods are vague and say `any`.

Rearrange the layout of the declarations to match what dts-gen emitted
(By dts-gen's design, this should match with the signature of `require('avsc')`)

- Keep the precise annotations that were already made, moving some.
- Make interfaces into classes where they correspond to an actual JS
  class (i.e. has function and function prototype)

A TODO was added to make places using types of `any` specific later.
I'm not familiar enough with this project to be certain of the intent,
and adding the methods/classes is a large enough PR on its own.

Add types/ folder to the package for `tsc`.

- This is necessary for that folder to be included in the package
  published to NPM

The namespaces and classes were generated by `dts-gen`.
Many `any` types are left over, I added a TODO to finish those later

I ran `tsc --strict` in a project that had a dependency of `avsc` to test this.
(The project uses only a few parts of avsc)

- Analysis of avsc.Type.forSchema worked as expected in a project that used
  a patched version of node_modules/avsc, with types/ subfolder added.
  (And toBuffer).
  (So, I know it is valid typescript)