### PR TITLE
Add the `types/` folder to the published NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   ],
   "files": [
     "lib",
-    "etc/browser"
+    "etc/browser",
+    "types"
   ],
   "main": "./lib",
   "types": "./types",


### PR DESCRIPTION
Currently, `tsc --strict` warns for projects with a dependency on
the latest avsc (5.1.2) due to the folder types/ not being included in the
published package.