### PR TITLE
Fix creating a resolver when a record field name is a javascript keyword

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -2339,7 +2339,7 @@ RecordType.prototype._update = function (resolver, type, opts) {
       } else {
         resolvers[name].push(fieldResolver);
       }
-      innerArgs.push(field.name);
+      innerArgs.push('_' + field.name);
     }
   }
 
@@ -2372,7 +2372,7 @@ RecordType.prototype._update = function (resolver, type, opts) {
         args.push('r' + i + 'f' + j);
         fieldResolver = resolvers[name][j];
         values.push(fieldResolver.resolver);
-        body += 'var ' + fieldResolver.name + ' = ';
+        body += 'var _' + fieldResolver.name + ' = ';
         body += 'r' + i + 'f' + j + '._' + (j ? 'peek' : 'read') + '(t);\n';
       }
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -2332,14 +2332,14 @@ RecordType.prototype._update = function (resolver, type, opts) {
       name = matches[0];
       fieldResolver = {
         resolver: field.type.createResolver(wFieldsMap[name].type, opts),
-        name: field.name, // Reader field name.
+        name: '_' + field.name, // Reader field name.
       };
       if (!resolvers[name]) {
         resolvers[name] = [fieldResolver];
       } else {
         resolvers[name].push(fieldResolver);
       }
-      innerArgs.push('_' + field.name);
+      innerArgs.push(fieldResolver.name);
     }
   }
 
@@ -2372,7 +2372,7 @@ RecordType.prototype._update = function (resolver, type, opts) {
         args.push('r' + i + 'f' + j);
         fieldResolver = resolvers[name][j];
         values.push(fieldResolver.resolver);
-        body += 'var _' + fieldResolver.name + ' = ';
+        body += 'var ' + fieldResolver.name + ' = ';
         body += 'r' + i + 'f' + j + '._' + (j ? 'peek' : 'read') + '(t);\n';
       }
     }

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -1713,6 +1713,25 @@ suite('types', function () {
       assert.deepEqual(v2.fromBuffer(buf, resolver), {name: 'Ann', age: 25});
     });
 
+    test('resolve field with javascript keyword as name', function () {
+      var v1 = Type.forSchema({
+        type: 'record',
+        name: 'Person',
+        fields: [{name: 'void', type: 'string'}]
+      });
+      var p = {void: 'Ann'};
+      var buf = v1.toBuffer(p);
+      var v2 = Type.forSchema({
+        type: 'record',
+        name: 'Person',
+        fields: [
+          {name: 'void', type: 'string'}
+        ]
+      });
+      var resolver = v2.createResolver(v1);
+      assert.deepEqual(v2.fromBuffer(buf, resolver), {void: 'Ann'});
+    });
+
     test('resolve new field no default', function () {
       var v1 = Type.forSchema({
         type: 'record',


### PR DESCRIPTION
Because the resolver creates cpde that uses field names as variables you get an error if you use a javascript keyword as a record field name when creating a resolver:
```
SyntaxError: Unexpected token void
    at new Function (<anonymous>)
    at RecordType._update (/code/node_modules/avsc/lib/types.js:2385:20)
    at RecordType.Type.createResolver (/code/node_modules/avsc/lib/types.js:523:10)
    at RecordType._update (/code/node_modules/avsc/lib/types.js:2334:30)
    at RecordType.Type.createResolver (/code/node_modules/avsc/lib/types.js:523:10)
```

Fix is a little lazy, but it works and it'd make field names starting with numbers work too. I considered making an object to store the data but that might affect performance.