### PR TITLE
Fix line causing an error in typescript 2.7.2

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,7 +69,7 @@ export class Type {
   toJSON(): string;
   toString(val?: any): any;
   wrap(val: any): any;
-  _skip(tap: any);
+  _skip(tap: any): any;
   readonly aliases: string[]|undefined;
   readonly doc: string|undefined;
   readonly name: string|undefined;


### PR DESCRIPTION
Seen in a typescript project using avsc:
(And using --strict)

```
node_modules/avsc/types/index.d.ts(72,3): error TS7010: '_skip', which
lacks return-type annotation, implicitly has an 'any' return type.
```