### PR TITLE
Encoding Namespaced objects with similar names

### DIFF
--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3556,6 +3556,41 @@ suite('types', function () {
       assert.throws(function () { t.encode('hi', buf, -1); });
     });
 
+    ['fooWrapped', 'wrapped.foo'].forEach(function(name) {
+
+      test('nested schema with registry: ' + name, function() {
+        var a = {
+          name: name,
+          type: 'record',
+          fields: [
+            { name: 'a', type: 'boolean'},
+            { name: 'b', type: 'foo'}
+          ]
+        }
+        
+        var b = {
+          name: 'foo',
+          type: 'record',
+          fields: [
+            { name: 'c', type: 'boolean'}
+          ]
+        };
+        var t = Type.forSchema(a, { registry: {
+          foo: Type.forSchema(b)
+        }});
+
+        var buf = new Buffer(50);
+        // fails for wrapped.foo, because _createWriter creates
+        // a function who's name is the same as the create writer
+        // function for the foo model. I don't know what the best approach is
+        // to address as I don't think the functions should be polluting each other's
+        // js namespaces. If addressing that isn't an option maybe there's a way to encompass
+        // the namespace in the function naming?
+        t.encode({ a: true, b: { c : true } }, buf);
+
+      });
+
+    });
   });
 
   suite('inspect', function () {


### PR DESCRIPTION
Failing test case for an edge case I found, see comments in code for my diagnosis.

https://github.com/mtth/avsc/blob/1c8f7a49abaf91bddc6f8dd3b4f08e2f263cd038/lib/types.js#L2105
gives an unqualified name which causes the function's to override each other.

So in the test case example -- it's trying to encode `record.b` with the encoder for `wrapped.foo` instead of the encoder from `foo`

/cc @mtth 