### PR TITLE
Align with apache commons avro implementation: Don't validate namespace when qualifying name

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -2876,16 +2876,20 @@ function unqualify(name) {
  * @param namespace {String} Optional namespace.
  */
 function qualify(name, namespace) {
-  if (~name.indexOf('.')) {
+  var globalNamespace = ~name.indexOf('.');
+  if (globalNamespace) {
     name = name.replace(/^\./, ''); // Allow absolute referencing.
-  } else if (namespace) {
-    name = namespace + '.' + name;
   }
-  name.split('.').forEach(function (part) {
+  name.split('.').forEach(function(part) {
     if (!isValidName(part)) {
       throw new Error(f('invalid name: %j', name));
     }
   });
+
+  if (!globalNamespace && namespace) {
+    name = namespace + '.' + name;
+  }
+
   var tail = unqualify(name);
   // Primitives are always in the global namespace.
   return isPrimitive(tail) ? tail : name;

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3455,6 +3455,13 @@ suite('types', function () {
       assert.equal(type.fields[0].type.name, 'a.Person');
     });
 
+    test('non-standard namespace', function () {
+      var type = Type.forSchema({
+        type: 'fixed', name: '_ID', size: 3, namespace: '1a'
+      });
+      assert.equal(type.getName(), '1a._ID');
+    })
+
     test('namespaced global', function () {
       var type = Type.forSchema({
         type: 'record',
@@ -3526,10 +3533,6 @@ suite('types', function () {
       // Name.
       assert.throws(function () {
         Type.forSchema({type: 'fixed', name: 'ID$', size: 3});
-      });
-      // Namespace.
-      assert.throws(function () {
-        Type.forSchema({type: 'fixed', name: 'ID', size: 3, namespace: '1a'});
       });
       // Qualified.
       assert.throws(function () {
@@ -3951,7 +3954,6 @@ suite('types', function () {
     });
 
   });
-
 });
 
 function testType(Type, data, invalidSchemas) {


### PR DESCRIPTION
Upon investigating the way name validation works in AVSC vs. the Apache Commons Java implementation of the Avro spec, I noticed a discrepancy.
Specifically, when qualifying a name/namespace, avsc validates **both** the _name_ and the _namespace_. This is because the _qualify_ method adds the namespace to the name **before** doing any validation.
The Java implementation in Apache Commons, however, behaves differently. As seen here: [Java](https://github.com/apache/avro/blob/master/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L512-L518), this standard implementation only validates the _name_, not the _namespace_ portion. This means that when the name/namespace combination looks something like 'test_name','test.1.namespace', avsc will consider this an error case, whereas the Apache Commons implementation will not.

This pull request seeks to resolve this discrepancy, and add appropriate tests.

The Avro spec isn't super specific about this case, but on first reading it feels like AVSC is actually **more** strictly following the spec than the Apache commons implementation, but seeing as the latter is more "standard", it feels like making the change here to align with that established library is more reasonable.
