### PR TITLE
Fix hang on empty block

### DIFF
--- a/lib/containers.js
+++ b/lib/containers.js
@@ -280,6 +280,9 @@ BlockDecoder.prototype._read = function () {
       } else {
         this._needPush = true;
       }
+      if (data) {
+        return data.cb();
+      }
       return; // Wait for more data.
     }
     data.cb();


### PR DESCRIPTION
I am decoding some avro files in my app and noticed that some of the files would hang forever when decoding...the `BlockDecoder` would never emit the `end` event.  I tried to reproduce the issue with some tests, but wasn't able to generate an avro file that demonstrated the behavior other than some large avro files I can't share here unfortunately.  I am not a fan of doing pull requests without tests, but was unable to build a test.  The issue is at the end of my decoding I saw this when I added `console.log(data)` to line `277` of `lib/containers.js`:

```
BlockData { index: 134, buf: <Buffer >, cb: [Function: chunkCb], count: 0 }
```

The above data block is the last block received.  There might be something invalid or missing in the file...I'm not sure, but when that data block is received we end up setting `this._needPush = true` but never calling `data.cb()` which makes the stream hang forever.  Adding the code below fixed the issue for me.

Do you have any idea of how to possibly simulate this with a test?  Using `avsc@5.4.1` does not have this issue, though the `BlockDecoder` does emit 1 additional empty message based on the schema of the file.