### PR TITLE
refactored lib/types and lib/utils to make rollup friendly

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,29 @@
+const rollup = require('rollup');
+const resolve = require('rollup-plugin-node-resolve');
+const cjs = require('rollup-plugin-commonjs');
+const terser = require('rollup-plugin-terser').terser;
+const builtins = require('rollup-plugin-node-builtins');
+
+async function build() {
+  const avsc = await rollup.rollup({
+    input: './etc/browser/avsc-types.js',
+    plugins: [
+      builtins(),
+      //nodeglobals(),
+      resolve({browser: true /*,preferBuiltins: false*/ }),
+      cjs(),
+      terser(),
+    ]
+  })
+    
+  await avsc.write({
+    name: "leader",
+    format: 'iife',
+    file: './avsc.js',
+    sourcemap: true
+  });
+
+}
+build().catch(err => {
+  console.error(err)
+})

--- a/lib/types.js
+++ b/lib/types.js
@@ -15,7 +15,7 @@
  */
 
 var utils = require('./utils'),
-    Buffer = buffer = require('buffer') // For `SlowBuffer`.
+    buffer = require('buffer') // For `SlowBuffer`.
 
 
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -15,14 +15,14 @@
  */
 
 var utils = require('./utils'),
-    buffer = require('buffer'), // For `SlowBuffer`.
-    util = require('util');
+    Buffer = buffer = require('buffer') // For `SlowBuffer`.
+
+
 
 
 // Convenience imports.
 var Tap = utils.Tap;
-var debug = util.debuglog('avsc:types');
-var f = util.format;
+//var debug = util.debuglog('avsc:types');
 
 // All non-union concrete (i.e. non-logical) Avro types.
 var TYPES = {
@@ -70,385 +70,660 @@ var UNDERLYING_TYPES = [];
  *
  *  See individual subclasses for details.
  */
-function Type(schema, opts) {
-  var type;
-  if (LOGICAL_TYPE) {
-    type = LOGICAL_TYPE;
-    UNDERLYING_TYPES.push([LOGICAL_TYPE, this]);
-    LOGICAL_TYPE = null;
-  } else {
-    type = this;
-  }
+class Type{
+  constructor(schema, opts) {
+    var type;
+    if (LOGICAL_TYPE) {
+      type = LOGICAL_TYPE;
+      UNDERLYING_TYPES.push([LOGICAL_TYPE, this]);
+      LOGICAL_TYPE = null;
+    } else {
+      type = this;
+    }
 
-  // Lazily instantiated hash string. It will be generated the first time the
-  // type's default fingerprint is computed (for example when using `equals`).
-  // We use a mutable object since types are frozen after instantiation.
-  this._hash = new Hash();
-  this.name = undefined;
-  this.aliases = undefined;
-  this.doc = (schema && schema.doc) ? '' + schema.doc : undefined;
+    // Lazily instantiated hash string. It will be generated the first time the
+    // type's default fingerprint is computed (for example when using `equals`).
+    // We use a mutable object since types are frozen after instantiation.
+    this._hash = new Hash();
+    this.name = undefined;
+    this.aliases = undefined;
+    this.doc = (schema && schema.doc) ? '' + schema.doc : undefined;
 
-  if (schema) {
-    // This is a complex (i.e. non-primitive) type.
-    var name = schema.name;
-    var namespace = schema.namespace === undefined ?
-      opts && opts.namespace :
-      schema.namespace;
-    if (name !== undefined) {
-      // This isn't an anonymous type.
-      name = qualify(name, namespace);
-      if (isPrimitive(name)) {
-        // Avro doesn't allow redefining primitive names.
-        throw new Error(f('cannot rename primitive type: %j', name));
-      }
-      var registry = opts && opts.registry;
-      if (registry) {
-        if (registry[name] !== undefined) {
-          throw new Error(f('duplicate type name: %s', name));
+    if (schema) {
+      // This is a complex (i.e. non-primitive) type.
+      var name = schema.name;
+      var namespace = schema.namespace === undefined ?
+        opts && opts.namespace :
+        schema.namespace;
+      if (name !== undefined) {
+        // This isn't an anonymous type.
+        name = qualify(name, namespace);
+        if (isPrimitive(name)) {
+          // Avro doesn't allow redefining primitive names.
+          throw new Error(`cannot rename primitive type: ${JSON.stringify(name)}`);
         }
-        registry[name] = type;
+        var registry = opts && opts.registry;
+        if (registry) {
+          if (registry[name] !== undefined) {
+            throw new Error(`duplicate type name: ${name}`);
+          }
+          registry[name] = type;
+        }
+      } else if (opts && opts.noAnonymousTypes) {
+        throw new Error(`missing name property in schema: ${JSON.stringify(schema)}`);
       }
-    } else if (opts && opts.noAnonymousTypes) {
-      throw new Error(f('missing name property in schema: %j', schema));
+      this.name = name;
+      this.aliases = schema.aliases ?
+        schema.aliases.map(function (s) { return qualify(s, namespace); }) :
+        [];
     }
-    this.name = name;
-    this.aliases = schema.aliases ?
-      schema.aliases.map(function (s) { return qualify(s, namespace); }) :
-      [];
-  }
-}
-
-Type.forSchema = function (schema, opts) {
-  opts = opts || {};
-  opts.registry = opts.registry || {};
-
-  var UnionType = (function (wrapUnions) {
-    if (wrapUnions === true) {
-      wrapUnions = 'always';
-    } else if (wrapUnions === false) {
-      wrapUnions = 'never';
-    } else if (wrapUnions === undefined) {
-      wrapUnions = 'auto';
-    } else if (typeof wrapUnions == 'string') {
-      wrapUnions = wrapUnions.toLowerCase();
-    }
-    switch (wrapUnions) {
-      case 'always':
-        return WrappedUnionType;
-      case 'never':
-        return UnwrappedUnionType;
-      case 'auto':
-        return undefined; // Determined dynamically later on.
-      default:
-        throw new Error(f('invalid wrap unions option: %j', wrapUnions));
-    }
-  })(opts.wrapUnions);
-
-  if (schema === null) {
-    // Let's be helpful for this common error.
-    throw new Error('invalid type: null (did you mean "null"?)');
   }
 
-  if (Type.isType(schema)) {
-    return schema;
-  }
+  static forSchema(schema, opts) {
+    opts = opts || {};
+    opts.registry = opts.registry || {};
 
-  var type;
-  if (opts.typeHook && (type = opts.typeHook(schema, opts))) {
-    if (!Type.isType(type)) {
-      throw new Error(f('invalid typehook return value: %j', type));
+    var UnionType = (function (wrapUnions) {
+      if (wrapUnions === true) {
+        wrapUnions = 'always';
+      } else if (wrapUnions === false) {
+        wrapUnions = 'never';
+      } else if (wrapUnions === undefined) {
+        wrapUnions = 'auto';
+      } else if (typeof wrapUnions == 'string') {
+        wrapUnions = wrapUnions.toLowerCase();
+      }
+      switch (wrapUnions) {
+        case 'always':
+          return WrappedUnionType;
+        case 'never':
+          return UnwrappedUnionType;
+        case 'auto':
+          return undefined; // Determined dynamically later on.
+        default:
+          throw new Error(`invalid wrap unions option: ${JSON.stringify(wrapUnions)}`);
+      }
+    })(opts.wrapUnions);
+
+    if (schema === null) {
+      // Let's be helpful for this common error.
+      throw new Error('invalid type: null (did you mean "null"?)');
+    }
+
+    if (Type.isType(schema)) {
+      return schema;
+    }
+
+    var type;
+    if (opts.typeHook && (type = opts.typeHook(schema, opts))) {
+      if (!Type.isType(type)) {
+        throw new Error(`invalid typehook return value: ${JSON.stringify(type)}`);
+      }
+      return type;
+    }
+
+    if (typeof schema == 'string') { // Type reference.
+      schema = qualify(schema, opts.namespace);
+      type = opts.registry[schema];
+      if (type) {
+        // Type was already defined, return it.
+        return type;
+      }
+      if (isPrimitive(schema)) {
+        // Reference to a primitive type. These are also defined names by default
+        // so we create the appropriate type and it to the registry for future
+        // reference.
+        return opts.registry[schema] = Type.forSchema({ type: schema }, opts);
+      }
+      throw new Error(`undefined type name: ${schema}`);
+    }
+
+    if (schema.logicalType && opts.logicalTypes && !LOGICAL_TYPE) {
+      var DerivedType = opts.logicalTypes[schema.logicalType];
+      if (DerivedType) {
+        var namespace = opts.namespace;
+        var registry = {};
+        Object.keys(opts.registry).forEach(function (key) {
+          registry[key] = opts.registry[key];
+        });
+        try {
+          //debug('instantiating logical type for %s', schema.logicalType);
+          return new DerivedType(schema, opts);
+        } catch (err) {
+          //debug('failed to instantiate logical type for %s', schema.logicalType);
+          if (opts.assertLogicalTypes) {
+            // The spec mandates that we fall through to the underlying type if
+            // the logical type is invalid. We provide this option to ease
+            // debugging.
+            throw err;
+          }
+          LOGICAL_TYPE = null;
+          opts.namespace = namespace;
+          opts.registry = registry;
+        }
+      }
+    }
+
+    if (Array.isArray(schema)) { // Union.
+      var types = schema.map(function (obj) {
+        return Type.forSchema(obj, opts);
+      });
+      if (!UnionType) {
+        UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
+      }
+      type = new UnionType(types, opts);
+    } else { // New type definition.
+      type = (function (typeName) {
+        var Type = TYPES[typeName];
+        if (Type === undefined) {
+          throw new Error(`unknown type: ${JSON.stringify(typeName)}`);
+        }
+        return new Type(schema, opts);
+      })(schema.type);
     }
     return type;
   }
 
-  if (typeof schema == 'string') { // Type reference.
-    schema = qualify(schema, opts.namespace);
-    type = opts.registry[schema];
-    if (type) {
-      // Type was already defined, return it.
-      return type;
-    }
-    if (isPrimitive(schema)) {
-      // Reference to a primitive type. These are also defined names by default
-      // so we create the appropriate type and it to the registry for future
-      // reference.
-      return opts.registry[schema] = Type.forSchema({type: schema}, opts);
-    }
-    throw new Error(f('undefined type name: %s', schema));
-  }
+  static forValue(val, opts) {
+    opts = opts || {};
 
-  if (schema.logicalType && opts.logicalTypes && !LOGICAL_TYPE) {
-    var DerivedType = opts.logicalTypes[schema.logicalType];
-    if (DerivedType) {
-      var namespace = opts.namespace;
-      var registry = {};
-      Object.keys(opts.registry).forEach(function (key) {
-        registry[key] = opts.registry[key];
-      });
-      try {
-        debug('instantiating logical type for %s', schema.logicalType);
-        return new DerivedType(schema, opts);
-      } catch (err) {
-        debug('failed to instantiate logical type for %s', schema.logicalType);
-        if (opts.assertLogicalTypes) {
-          // The spec mandates that we fall through to the underlying type if
-          // the logical type is invalid. We provide this option to ease
-          // debugging.
-          throw err;
-        }
-        LOGICAL_TYPE = null;
-        opts.namespace = namespace;
-        opts.registry = registry;
-      }
-    }
-  }
-
-  if (Array.isArray(schema)) { // Union.
-    var types = schema.map(function (obj) {
-      return Type.forSchema(obj, opts);
+    // Sentinel used when inferring the types of empty arrays.
+    opts.emptyArrayType = opts.emptyArrayType || Type.forSchema({
+      type: 'array', items: 'null'
     });
-    if (!UnionType) {
-      UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
-    }
-    type = new UnionType(types, opts);
-  } else { // New type definition.
-    type = (function (typeName) {
-      var Type = TYPES[typeName];
-      if (Type === undefined) {
-        throw new Error(f('unknown type: %j', typeName));
-      }
-      return new Type(schema, opts);
-    })(schema.type);
-  }
-  return type;
-};
 
-Type.forValue = function (val, opts) {
-  opts = opts || {};
-
-  // Sentinel used when inferring the types of empty arrays.
-  opts.emptyArrayType = opts.emptyArrayType || Type.forSchema({
-    type: 'array', items: 'null'
-  });
-
-  // Optional custom inference hook.
-  if (opts.valueHook) {
-    var type = opts.valueHook(val, opts);
-    if (type !== undefined) {
-      if (!Type.isType(type)) {
-        throw new Error(f('invalid value hook return value: %j', type));
-      }
-      return type;
-    }
-  }
-
-  // Default inference logic.
-  switch (typeof val) {
-    case 'string':
-      return Type.forSchema('string', opts);
-    case 'boolean':
-      return Type.forSchema('boolean', opts);
-    case 'number':
-      if ((val | 0) === val) {
-        return Type.forSchema('int', opts);
-      } else if (Math.abs(val) < 9007199254740991) {
-        return Type.forSchema('float', opts);
-      }
-      return Type.forSchema('double', opts);
-    case 'object':
-      if (val === null) {
-        return Type.forSchema('null', opts);
-      } else if (Array.isArray(val)) {
-        if (!val.length) {
-          return opts.emptyArrayType;
+    // Optional custom inference hook.
+    if (opts.valueHook) {
+      var type = opts.valueHook(val, opts);
+      if (type !== undefined) {
+        if (!Type.isType(type)) {
+          throw new Error(`invalid value hook return value: ${JSON.stringify(type)}`);
         }
-        return Type.forSchema({
-          type: 'array',
-          items: Type.forTypes(
-            val.map(function (v) { return Type.forValue(v, opts); })
-          )
-        }, opts);
-      } else if (Buffer.isBuffer(val)) {
-        return Type.forSchema('bytes', opts);
+        return type;
       }
-      var fieldNames = Object.keys(val);
-      if (fieldNames.some(function (s) { return !isValidName(s); })) {
-        // We have to fall back to a map.
-        return Type.forSchema({
-          type: 'map',
-          values: Type.forTypes(fieldNames.map(function (s) {
-            return Type.forValue(val[s], opts);
-          }), opts)
-        }, opts);
-      }
-      return Type.forSchema({
-        type: 'record',
-        fields: fieldNames.map(function (s) {
-          return {name: s, type: Type.forValue(val[s], opts)};
-        })
-      }, opts);
-    default:
-      throw new Error(f('cannot infer type from: %j', val));
-  }
-};
-
-Type.forTypes = function (types, opts) {
-  if (!types.length) {
-    throw new Error('no types to combine');
-  }
-  if (types.length === 1) {
-    return types[0]; // Nothing to do.
-  }
-  opts = opts || {};
-
-  // Extract any union types, with special care for wrapped unions (see below).
-  var expanded = [];
-  var numWrappedUnions = 0;
-  var isValidWrappedUnion = true;
-  types.forEach(function (type) {
-    switch (type.typeName) {
-      case 'union:unwrapped':
-        isValidWrappedUnion = false;
-        expanded = expanded.concat(type.types);
-        break;
-      case 'union:wrapped':
-        numWrappedUnions++;
-        expanded = expanded.concat(type.types);
-        break;
-      case 'null':
-        expanded.push(type);
-        break;
-      default:
-        isValidWrappedUnion = false;
-        expanded.push(type);
     }
-  });
-  if (numWrappedUnions) {
-    if (!isValidWrappedUnion) {
-      // It is only valid to combine wrapped unions when no other type is
-      // present other than wrapped unions and nulls (otherwise the values of
-      // others wouldn't be valid in the resulting union).
-      throw new Error('cannot combine wrapped union');
-    }
-    var branchTypes = {};
-    expanded.forEach(function (type) {
-      var name = type.branchName;
-      var branchType = branchTypes[name];
-      if (!branchType) {
-        branchTypes[name] = type;
-      } else if (!type.equals(branchType)) {
-        throw new Error('inconsistent branch type');
-      }
-    });
-    var wrapUnions = opts.wrapUnions;
-    var unionType;
-    opts.wrapUnions = true;
-    try {
-      unionType = Type.forSchema(Object.keys(branchTypes).map(function (name) {
-        return branchTypes[name];
-      }), opts);
-    } catch (err) {
-      opts.wrapUnions = wrapUnions;
-      throw err;
-    }
-    opts.wrapUnions = wrapUnions;
-    return unionType;
-  }
 
-  // Group types by category, similar to the logic for unwrapped unions.
-  var bucketized = {};
-  expanded.forEach(function (type) {
-    var bucket = getTypeBucket(type);
-    var bucketTypes = bucketized[bucket];
-    if (!bucketTypes) {
-      bucketized[bucket] = bucketTypes = [];
-    }
-    bucketTypes.push(type);
-  });
-
-  // Generate the "augmented" type for each group.
-  var buckets = Object.keys(bucketized);
-  var augmented = buckets.map(function (bucket) {
-    var bucketTypes = bucketized[bucket];
-    if (bucketTypes.length === 1) {
-      return bucketTypes[0];
-    } else {
-      switch (bucket) {
-        case 'null':
-        case 'boolean':
-          return bucketTypes[0];
-        case 'number':
-          return combineNumbers(bucketTypes);
-        case 'string':
-          return combineStrings(bucketTypes, opts);
-        case 'buffer':
-          return combineBuffers(bucketTypes, opts);
-        case 'array':
-          // Remove any sentinel arrays (used when inferring from empty arrays)
-          // to avoid making things nullable when they shouldn't be.
-          bucketTypes = bucketTypes.filter(function (t) {
-            return t !== opts.emptyArrayType;
-          });
-          if (!bucketTypes.length) {
-            // We still don't have a real type, just return the sentinel.
+    // Default inference logic.
+    switch (typeof val) {
+      case 'string':
+        return Type.forSchema('string', opts);
+      case 'boolean':
+        return Type.forSchema('boolean', opts);
+      case 'number':
+        if ((val | 0) === val) {
+          return Type.forSchema('int', opts);
+        } else if (Math.abs(val) < 9007199254740991) {
+          return Type.forSchema('float', opts);
+        }
+        return Type.forSchema('double', opts);
+      case 'object':
+        if (val === null) {
+          return Type.forSchema('null', opts);
+        } else if (Array.isArray(val)) {
+          if (!val.length) {
             return opts.emptyArrayType;
           }
           return Type.forSchema({
             type: 'array',
-            items: Type.forTypes(bucketTypes.map(function (t) {
-              return t.itemsType;
-            }))
+            items: Type.forTypes(
+              val.map(function (v) { return Type.forValue(v, opts); })
+            )
           }, opts);
-        default:
-          return combineObjects(bucketTypes, opts);
-      }
+        } else if (Buffer.isBuffer(val)) {
+          return Type.forSchema('bytes', opts);
+        }
+        var fieldNames = Object.keys(val);
+        if (fieldNames.some(function (s) { return !isValidName(s); })) {
+          // We have to fall back to a map.
+          return Type.forSchema({
+            type: 'map',
+            values: Type.forTypes(fieldNames.map(function (s) {
+              return Type.forValue(val[s], opts);
+            }), opts)
+          }, opts);
+        }
+        return Type.forSchema({
+          type: 'record',
+          fields: fieldNames.map(function (s) {
+            return { name: s, type: Type.forValue(val[s], opts) };
+          })
+        }, opts);
+      default:
+        throw new Error(`cannot infer type from: ${JSON.stringify(val)}`);
     }
-  });
-
-  if (augmented.length === 1) {
-    return augmented[0];
-  } else {
-    // We return an (unwrapped) union of all augmented types.
-    return Type.forSchema(augmented, opts);
-  }
-};
-
-Type.isType = function (/* any, [prefix] ... */) {
-  var l = arguments.length;
-  if (!l) {
-    return false;
   }
 
-  var any = arguments[0];
-  if (
-    !any ||
-    typeof any._update != 'function' ||
-    typeof any.fingerprint != 'function'
-  ) {
-    // Not fool-proof, but most likely good enough.
-    return false;
+  static forTypes(types, opts) {
+    if (!types.length) {
+      throw new Error('no types to combine');
+    }
+    if (types.length === 1) {
+      return types[0]; // Nothing to do.
+    }
+    opts = opts || {};
+
+    // Extract any union types, with special care for wrapped unions (see below).
+    var expanded = [];
+    var numWrappedUnions = 0;
+    var isValidWrappedUnion = true;
+    types.forEach(function (type) {
+      switch (type.typeName) {
+        case 'union:unwrapped':
+          isValidWrappedUnion = false;
+          expanded = expanded.concat(type.types);
+          break;
+        case 'union:wrapped':
+          numWrappedUnions++;
+          expanded = expanded.concat(type.types);
+          break;
+        case 'null':
+          expanded.push(type);
+          break;
+        default:
+          isValidWrappedUnion = false;
+          expanded.push(type);
+      }
+    });
+    if (numWrappedUnions) {
+      if (!isValidWrappedUnion) {
+        // It is only valid to combine wrapped unions when no other type is
+        // present other than wrapped unions and nulls (otherwise the values of
+        // others wouldn't be valid in the resulting union).
+        throw new Error('cannot combine wrapped union');
+      }
+      var branchTypes = {};
+      expanded.forEach(function (type) {
+        var name = type.branchName;
+        var branchType = branchTypes[name];
+        if (!branchType) {
+          branchTypes[name] = type;
+        } else if (!type.equals(branchType)) {
+          throw new Error('inconsistent branch type');
+        }
+      });
+      var wrapUnions = opts.wrapUnions;
+      var unionType;
+      opts.wrapUnions = true;
+      try {
+        unionType = Type.forSchema(Object.keys(branchTypes).map(function (name) {
+          return branchTypes[name];
+        }), opts);
+      } catch (err) {
+        opts.wrapUnions = wrapUnions;
+        throw err;
+      }
+      opts.wrapUnions = wrapUnions;
+      return unionType;
+    }
+
+    // Group types by category, similar to the logic for unwrapped unions.
+    var bucketized = {};
+    expanded.forEach(function (type) {
+      var bucket = getTypeBucket(type);
+      var bucketTypes = bucketized[bucket];
+      if (!bucketTypes) {
+        bucketized[bucket] = bucketTypes = [];
+      }
+      bucketTypes.push(type);
+    });
+
+    // Generate the "augmented" type for each group.
+    var buckets = Object.keys(bucketized);
+    var augmented = buckets.map(function (bucket) {
+      var bucketTypes = bucketized[bucket];
+      if (bucketTypes.length === 1) {
+        return bucketTypes[0];
+      } else {
+        switch (bucket) {
+          case 'null':
+          case 'boolean':
+            return bucketTypes[0];
+          case 'number':
+            return combineNumbers(bucketTypes);
+          case 'string':
+            return combineStrings(bucketTypes, opts);
+          case 'buffer':
+            return combineBuffers(bucketTypes, opts);
+          case 'array':
+            // Remove any sentinel arrays (used when inferring from empty arrays)
+            // to avoid making things nullable when they shouldn't be.
+            bucketTypes = bucketTypes.filter(function (t) {
+              return t !== opts.emptyArrayType;
+            });
+            if (!bucketTypes.length) {
+              // We still don't have a real type, just return the sentinel.
+              return opts.emptyArrayType;
+            }
+            return Type.forSchema({
+              type: 'array',
+              items: Type.forTypes(bucketTypes.map(function (t) {
+                return t.itemsType;
+              }))
+            }, opts);
+          default:
+            return combineObjects(bucketTypes, opts);
+        }
+      }
+    });
+
+    if (augmented.length === 1) {
+      return augmented[0];
+    } else {
+      // We return an (unwrapped) union of all augmented types.
+      return Type.forSchema(augmented, opts);
+    }
   }
 
-  if (l === 1) {
-    // No type names specified, we are done.
-    return true;
-  }
+  static isType(/* any, [prefix] ... */) {
+    var l = arguments.length;
+    if (!l) {
+      return false;
+    }
 
-  // We check if at least one of the prefixes matches.
-  var typeName = any.typeName;
-  var i;
-  for (i = 1; i < l; i++) {
-    if (typeName.indexOf(arguments[i]) === 0) {
+    var any = arguments[0];
+    if (
+      !any ||
+      typeof any._update != 'function' ||
+      typeof any.fingerprint != 'function'
+    ) {
+      // Not fool-proof, but most likely good enough.
+      return false;
+    }
+
+    if (l === 1) {
+      // No type names specified, we are done.
       return true;
     }
-  }
-  return false;
-};
 
-Type.__reset = function (size) {
-  debug('resetting type buffer to %d', size);
-  TAP.buf = new buffer.SlowBuffer(size);
-};
+    // We check if at least one of the prefixes matches.
+    var typeName = any.typeName;
+    var i;
+    for (i = 1; i < l; i++) {
+      if (typeName.indexOf(arguments[i]) === 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static __reset(size) {
+    //debug('resetting type buffer to %d', size);
+    TAP.buf = new buffer.SlowBuffer(size);
+  }
+
+  clone(val, opts) {
+    if (opts) {
+      opts = {
+        coerce: !!opts.coerceBuffers | 0, // Coerce JSON to Buffer.
+        fieldHook: opts.fieldHook,
+        qualifyNames: !!opts.qualifyNames,
+        skip: !!opts.skipMissingFields,
+        wrap: !!opts.wrapUnions | 0 // Wrap first match into union.
+      };
+      return this._copy(val, opts);
+    } else {
+      // If no modifications are required, we can get by with a serialization
+      // roundtrip (generally much faster than a standard deep copy).
+      return this.fromBuffer(this.toBuffer(val));
+    }
+  };
+
+  compareBuffers(buf1, buf2) {
+    return this._match(new Tap(buf1), new Tap(buf2));
+  };
+
+  createResolver(type, opts) {
+    if (!Type.isType(type)) {
+      // More explicit error message than the "incompatible type" thrown
+      // otherwise (especially because of the overridden `toJSON` method).
+      throw new Error(`not a type: ${JSON.stringify(type)}`);
+    }
+
+    if (!Type.isType(this, 'union', 'logical') && Type.isType(type, 'logical')) {
+      // Trying to read a logical type as a built-in: unwrap the logical type.
+      // Note that we exclude unions to support resolving into unions containing
+      // logical types.
+      return this.createResolver(type.underlyingType, opts);
+    }
+
+    opts = opts || {};
+    opts.registry = opts.registry || {};
+
+    var resolver, key;
+    if (
+      Type.isType(this, 'record', 'error') &&
+      Type.isType(type, 'record', 'error')
+    ) {
+      // We allow conversions between records and errors.
+      key = this.name + ':' + type.name; // ':' is illegal in Avro type names.
+      resolver = opts.registry[key];
+      if (resolver) {
+        return resolver;
+      }
+    }
+
+    resolver = new Resolver(this);
+    if (key) { // Register resolver early for recursive schemas.
+      opts.registry[key] = resolver;
+    }
+
+    if (Type.isType(type, 'union')) {
+      var resolvers = type.types.map(function (t) {
+        return this.createResolver(t, opts);
+      }, this);
+      resolver._read = function (tap) {
+        var index = tap.readLong();
+        var resolver = resolvers[index];
+        if (resolver === undefined) {
+          throw new Error(`invalid union index: ${index}`);
+        }
+        return resolvers[index]._read(tap);
+      };
+    } else {
+      this._update(resolver, type, opts);
+    }
+
+    if (!resolver._read) {
+      throw new Error(`cannot read ${type} as ${this}`);
+    }
+    return Object.freeze(resolver);
+  };
+
+  decode(buf, pos, resolver) {
+    var tap = new Tap(buf, pos);
+    var val = readValue(this, tap, resolver);
+    if (!tap.isValid()) {
+      return { value: undefined, offset: -1 };
+    }
+    return { value: val, offset: tap.pos };
+  };
+
+  encode(val, buf, pos) {
+    var tap = new Tap(buf, pos);
+    this._write(tap, val);
+    if (!tap.isValid()) {
+      // Don't throw as there is no way to predict this. We also return the
+      // number of missing bytes to ease resizing.
+      return buf.length - tap.pos;
+    }
+    return tap.pos;
+  };
+
+  equals(type) {
+    return (
+      Type.isType(type) &&
+      this.fingerprint().equals(type.fingerprint())
+    );
+  };
+
+  fingerprint(algorithm) {
+    if (!algorithm) {
+      if (!this._hash.str) {
+        var schemaStr = JSON.stringify(this.schema());
+        this._hash.str = utils.getHash(schemaStr).toString('binary');
+      }
+      return utils.bufferFrom(this._hash.str, 'binary');
+    } else {
+      return utils.getHash(JSON.stringify(this.schema()), algorithm);
+    }
+  };
+
+  fromBuffer(buf, resolver, noCheck) {
+    var tap = new Tap(buf);
+    var val = readValue(this, tap, resolver, noCheck);
+    if (!tap.isValid()) {
+      throw new Error('truncated buffer');
+    }
+    if (!noCheck && tap.pos < buf.length) {
+      throw new Error('trailing data');
+    }
+    return val;
+  };
+
+  fromString(str) {
+    return this._copy(JSON.parse(str), { coerce: 2 });
+  };
+
+  inspect() {
+    var typeName = this.typeName;
+    var className = getClassName(typeName);
+    if (isPrimitive(typeName)) {
+      // The class name is sufficient to identify the type.
+      return `<${className}>`;
+    } else {
+      // We add a little metadata for convenience.
+      var obj = this.schema({ exportAttrs: true, noDeref: true });
+      if (typeof obj == 'object' && !Type.isType(this, 'logical')) {
+        obj.type = undefined; // Would be redundant with constructor name.
+      }
+      return `<${className} ${JSON.stringify(obj)}>`;
+    }
+  };
+
+  isValid(val, opts) {
+    // We only have a single flag for now, so no need to complicate things.
+    var flags = (opts && opts.noUndeclaredFields) | 0;
+    var errorHook = opts && opts.errorHook;
+    var hook, path;
+    if (errorHook) {
+      path = [];
+      hook = function (any, type) {
+        errorHook.call(this, path.slice(), any, type, val);
+      };
+    }
+    return this._check(val, flags, hook, path);
+  };
+
+  schema(opts) {
+    // Copy the options to avoid mutating the original options object when we add
+    // the registry of dereferenced types.
+    return this._attrs({
+      exportAttrs: !!(opts && opts.exportAttrs),
+      noDeref: !!(opts && opts.noDeref)
+    });
+  };
+
+  toBuffer(val) {
+    TAP.pos = 0;
+    this._write(TAP, val);
+    var buf = utils.newBuffer(TAP.pos);
+    if (TAP.isValid()) {
+      TAP.buf.copy(buf, 0, 0, TAP.pos);
+    } else {
+      this._write(new Tap(buf), val);
+    }
+    return buf;
+  };
+
+  toJSON() {
+    // Convenience to allow using `JSON.stringify(type)` to get a type's schema.
+    return this.schema({ exportAttrs: true });
+  };
+
+  toString(val) {
+    if (val === undefined) {
+      // Consistent behavior with standard `toString` expectations.
+      return JSON.stringify(this.schema({ noDeref: true }));
+    }
+    return JSON.stringify(this._copy(val, { coerce: 3 }));
+  };
+
+  wrap(val) {
+    var Branch = this._branchConstructor;
+    return Branch === null ? null : new Branch(val);
+  };
+
+  _attrs(opts) {
+    // This function handles a lot of the common logic to schema generation
+    // across types, for example keeping track of which types have already been
+    // de-referenced (i.e. derefed).
+    opts.derefed = opts.derefed || {};
+    var name = this.name;
+    if (name !== undefined) {
+      if (opts.noDeref || opts.derefed[name]) {
+        return name;
+      }
+      opts.derefed[name] = true;
+    }
+    var schema = {};
+    // The order in which we add fields to the `schema` object matters here.
+    // Since JS objects are unordered, this implementation (unfortunately) relies
+    // on engines returning properties in the same order that they are inserted
+    // in. This is not in the JS spec, but can be "somewhat" safely assumed (see
+    // http://stackoverflow.com/q/5525795/1062617).
+    if (this.name !== undefined) {
+      schema.name = name;
+    }
+    schema.type = this.typeName;
+    var derefedSchema = this._deref(schema, opts);
+    if (derefedSchema !== undefined) {
+      // We allow the original schema to be overridden (this will happen for
+      // primitive types and logical types).
+      schema = derefedSchema;
+    }
+    if (opts.exportAttrs) {
+      if (this.aliases && this.aliases.length) {
+        schema.aliases = this.aliases;
+      }
+      if (this.doc !== undefined) {
+        schema.doc = this.doc;
+      }
+    }
+    return schema;
+  };
+
+  _createBranchConstructor() {
+    // jshint -W054
+    var name = this.branchName;
+    if (name === 'null') {
+      return null;
+    }
+    var attr = ~name.indexOf('.') ? 'this[\'' + name + '\']' : 'this.' + name;
+    var body = 'return function Branch$(val) { ' + attr + ' = val; };';
+    var Branch = (new Function(body))();
+    Branch.type = this;
+    Branch.prototype.unwrap = new Function('return ' + attr + ';');
+    Branch.prototype.unwrapped = Branch.prototype.unwrap; // Deprecated.
+    return Branch;
+  };
+
+  _peek(tap) {
+    var pos = tap.pos;
+    var val = this._read(tap);
+    tap.pos = pos;
+    return val;
+  };
+
+  // "Deprecated" getters (will be explicitly deprecated in 5.1).
+
+  getAliases() { return this.aliases; };
+
+  getName(asBranch) {
+    return (this.name || !asBranch) ? this.name : this.branchName;
+  };
+
+  getTypeName() { return this.typeName; };
+}
 
 Object.defineProperty(Type.prototype, 'branchName', {
   enumerable: true,
@@ -463,273 +738,9 @@ Object.defineProperty(Type.prototype, 'branchName', {
     return Type.isType(type, 'union') ? undefined : type.typeName;
   }
 });
-
-Type.prototype.clone = function (val, opts) {
-  if (opts) {
-    opts = {
-      coerce: !!opts.coerceBuffers | 0, // Coerce JSON to Buffer.
-      fieldHook: opts.fieldHook,
-      qualifyNames: !!opts.qualifyNames,
-      skip: !!opts.skipMissingFields,
-      wrap: !!opts.wrapUnions | 0 // Wrap first match into union.
-    };
-    return this._copy(val, opts);
-  } else {
-    // If no modifications are required, we can get by with a serialization
-    // roundtrip (generally much faster than a standard deep copy).
-    return this.fromBuffer(this.toBuffer(val));
-  }
-};
-
 Type.prototype.compare = utils.abstractFunction;
-
-Type.prototype.compareBuffers = function (buf1, buf2) {
-  return this._match(new Tap(buf1), new Tap(buf2));
-};
-
-Type.prototype.createResolver = function (type, opts) {
-  if (!Type.isType(type)) {
-    // More explicit error message than the "incompatible type" thrown
-    // otherwise (especially because of the overridden `toJSON` method).
-    throw new Error(f('not a type: %j', type));
-  }
-
-  if (!Type.isType(this, 'union', 'logical') && Type.isType(type, 'logical')) {
-    // Trying to read a logical type as a built-in: unwrap the logical type.
-    // Note that we exclude unions to support resolving into unions containing
-    // logical types.
-    return this.createResolver(type.underlyingType, opts);
-  }
-
-  opts = opts || {};
-  opts.registry = opts.registry || {};
-
-  var resolver, key;
-  if (
-    Type.isType(this, 'record', 'error') &&
-    Type.isType(type, 'record', 'error')
-  ) {
-    // We allow conversions between records and errors.
-    key = this.name + ':' + type.name; // ':' is illegal in Avro type names.
-    resolver = opts.registry[key];
-    if (resolver) {
-      return resolver;
-    }
-  }
-
-  resolver = new Resolver(this);
-  if (key) { // Register resolver early for recursive schemas.
-    opts.registry[key] = resolver;
-  }
-
-  if (Type.isType(type, 'union')) {
-    var resolvers = type.types.map(function (t) {
-      return this.createResolver(t, opts);
-    }, this);
-    resolver._read = function (tap) {
-      var index = tap.readLong();
-      var resolver = resolvers[index];
-      if (resolver === undefined) {
-        throw new Error(f('invalid union index: %s', index));
-      }
-      return resolvers[index]._read(tap);
-    };
-  } else {
-    this._update(resolver, type, opts);
-  }
-
-  if (!resolver._read) {
-    throw new Error(f('cannot read %s as %s', type, this));
-  }
-  return Object.freeze(resolver);
-};
-
-Type.prototype.decode = function (buf, pos, resolver) {
-  var tap = new Tap(buf, pos);
-  var val = readValue(this, tap, resolver);
-  if (!tap.isValid()) {
-    return {value: undefined, offset: -1};
-  }
-  return {value: val, offset: tap.pos};
-};
-
-Type.prototype.encode = function (val, buf, pos) {
-  var tap = new Tap(buf, pos);
-  this._write(tap, val);
-  if (!tap.isValid()) {
-    // Don't throw as there is no way to predict this. We also return the
-    // number of missing bytes to ease resizing.
-    return buf.length - tap.pos;
-  }
-  return tap.pos;
-};
-
-Type.prototype.equals = function (type) {
-  return (
-    Type.isType(type) &&
-    this.fingerprint().equals(type.fingerprint())
-  );
-};
-
-Type.prototype.fingerprint = function (algorithm) {
-  if (!algorithm) {
-    if (!this._hash.str) {
-      var schemaStr = JSON.stringify(this.schema());
-      this._hash.str = utils.getHash(schemaStr).toString('binary');
-    }
-    return utils.bufferFrom(this._hash.str, 'binary');
-  } else {
-    return utils.getHash(JSON.stringify(this.schema()), algorithm);
-  }
-};
-
-Type.prototype.fromBuffer = function (buf, resolver, noCheck) {
-  var tap = new Tap(buf);
-  var val = readValue(this, tap, resolver, noCheck);
-  if (!tap.isValid()) {
-    throw new Error('truncated buffer');
-  }
-  if (!noCheck && tap.pos < buf.length) {
-    throw new Error('trailing data');
-  }
-  return val;
-};
-
-Type.prototype.fromString = function (str) {
-  return this._copy(JSON.parse(str), {coerce: 2});
-};
-
-Type.prototype.inspect = function () {
-  var typeName = this.typeName;
-  var className = getClassName(typeName);
-  if (isPrimitive(typeName)) {
-    // The class name is sufficient to identify the type.
-    return f('<%s>', className);
-  } else {
-    // We add a little metadata for convenience.
-    var obj = this.schema({exportAttrs: true, noDeref: true});
-    if (typeof obj == 'object' && !Type.isType(this, 'logical')) {
-      obj.type = undefined; // Would be redundant with constructor name.
-    }
-    return f('<%s %j>', className, obj);
-  }
-};
-
-Type.prototype.isValid = function (val, opts) {
-  // We only have a single flag for now, so no need to complicate things.
-  var flags = (opts && opts.noUndeclaredFields) | 0;
-  var errorHook = opts && opts.errorHook;
-  var hook, path;
-  if (errorHook) {
-    path = [];
-    hook = function (any, type) {
-      errorHook.call(this, path.slice(), any, type, val);
-    };
-  }
-  return this._check(val, flags, hook, path);
-};
-
 Type.prototype.random = utils.abstractFunction;
 
-Type.prototype.schema = function (opts) {
-  // Copy the options to avoid mutating the original options object when we add
-  // the registry of dereferenced types.
-  return this._attrs({
-    exportAttrs: !!(opts && opts.exportAttrs),
-    noDeref: !!(opts && opts.noDeref)
-  });
-};
-
-Type.prototype.toBuffer = function (val) {
-  TAP.pos = 0;
-  this._write(TAP, val);
-  var buf = utils.newBuffer(TAP.pos);
-  if (TAP.isValid()) {
-    TAP.buf.copy(buf, 0, 0, TAP.pos);
-  } else {
-    this._write(new Tap(buf), val);
-  }
-  return buf;
-};
-
-Type.prototype.toJSON = function () {
-  // Convenience to allow using `JSON.stringify(type)` to get a type's schema.
-  return this.schema({exportAttrs: true});
-};
-
-Type.prototype.toString = function (val) {
-  if (val === undefined) {
-    // Consistent behavior with standard `toString` expectations.
-    return JSON.stringify(this.schema({noDeref: true}));
-  }
-  return JSON.stringify(this._copy(val, {coerce: 3}));
-};
-
-Type.prototype.wrap = function (val) {
-  var Branch = this._branchConstructor;
-  return Branch === null ? null : new Branch(val);
-};
-
-Type.prototype._attrs = function (opts) {
-  // This function handles a lot of the common logic to schema generation
-  // across types, for example keeping track of which types have already been
-  // de-referenced (i.e. derefed).
-  opts.derefed = opts.derefed || {};
-  var name = this.name;
-  if (name !== undefined) {
-    if (opts.noDeref || opts.derefed[name]) {
-      return name;
-    }
-    opts.derefed[name] = true;
-  }
-  var schema = {};
-  // The order in which we add fields to the `schema` object matters here.
-  // Since JS objects are unordered, this implementation (unfortunately) relies
-  // on engines returning properties in the same order that they are inserted
-  // in. This is not in the JS spec, but can be "somewhat" safely assumed (see
-  // http://stackoverflow.com/q/5525795/1062617).
-  if (this.name !== undefined) {
-    schema.name = name;
-  }
-  schema.type = this.typeName;
-  var derefedSchema = this._deref(schema, opts);
-  if (derefedSchema !== undefined) {
-    // We allow the original schema to be overridden (this will happen for
-    // primitive types and logical types).
-    schema = derefedSchema;
-  }
-  if (opts.exportAttrs) {
-    if (this.aliases && this.aliases.length) {
-      schema.aliases = this.aliases;
-    }
-    if (this.doc !== undefined) {
-      schema.doc = this.doc;
-    }
-  }
-  return schema;
-};
-
-Type.prototype._createBranchConstructor = function () {
-  // jshint -W054
-  var name = this.branchName;
-  if (name === 'null') {
-    return null;
-  }
-  var attr = ~name.indexOf('.') ? 'this[\'' + name + '\']' : 'this.' + name;
-  var body = 'return function Branch$(val) { ' + attr + ' = val; };';
-  var Branch = (new Function(body))();
-  Branch.type = this;
-  Branch.prototype.unwrap = new Function('return ' + attr + ';');
-  Branch.prototype.unwrapped = Branch.prototype.unwrap; // Deprecated.
-  return Branch;
-};
-
-Type.prototype._peek = function (tap) {
-  var pos = tap.pos;
-  var val = this._read(tap);
-  tap.pos = pos;
-  return val;
-};
 
 Type.prototype._check = utils.abstractFunction;
 Type.prototype._copy = utils.abstractFunction;
@@ -740,19 +751,11 @@ Type.prototype._skip = utils.abstractFunction;
 Type.prototype._update = utils.abstractFunction;
 Type.prototype._write = utils.abstractFunction;
 
+
 // "Deprecated" getters (will be explicitly deprecated in 5.1).
-
-Type.prototype.getAliases = function () { return this.aliases; };
-
 Type.prototype.getFingerprint = Type.prototype.fingerprint;
-
-Type.prototype.getName = function (asBranch) {
-  return (this.name || !asBranch) ? this.name : this.branchName;
-};
-
 Type.prototype.getSchema = Type.prototype.schema;
 
-Type.prototype.getTypeName = function () { return this.typeName; };
 
 // Implementations.
 
@@ -763,54 +766,57 @@ Type.prototype.getTypeName = function () { return this.typeName; };
  * mechanisms, provided by this class. This class also lets us conveniently
  * check whether a type is a primitive using `instanceof`.
  */
-function PrimitiveType(noFreeze) {
-  Type.call(this);
-  this._branchConstructor = this._createBranchConstructor();
-  if (!noFreeze) {
-    // Abstract long types can't be frozen at this stage.
-    Object.freeze(this);
+class PrimitiveType extends Type {
+  constructor(noFreeze) {
+    super();
+    this._branchConstructor = this._createBranchConstructor();
+    if (!noFreeze) {
+      // Abstract long types can't be frozen at this stage.
+      Object.freeze(this);
+    }
   }
+  _update(resolver, type) {
+    if (type.typeName === this.typeName) {
+      resolver._read = this._read;
+    }
+  };
+
+  _copy(val) {
+    this._check(val, undefined, throwInvalidError);
+    return val;
+  };
+
+  _deref() { return this.typeName; };
 }
-util.inherits(PrimitiveType, Type);
 
-PrimitiveType.prototype._update = function (resolver, type) {
-  if (type.typeName === this.typeName) {
-    resolver._read = this._read;
-  }
-};
-
-PrimitiveType.prototype._copy = function (val) {
-  this._check(val, undefined, throwInvalidError);
-  return val;
-};
-
-PrimitiveType.prototype._deref = function () { return this.typeName; };
 
 PrimitiveType.prototype.compare = utils.compare;
 
 /** Nulls. */
-function NullType() { PrimitiveType.call(this); }
-util.inherits(NullType, PrimitiveType);
+class NullType extends PrimitiveType {
+  constructor() { super() }
 
-NullType.prototype._check = function (val, flags, hook) {
-  var b = val === null;
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = val === null;
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-NullType.prototype._read = function () { return null; };
+  _read() { return null; };
 
-NullType.prototype._skip = function () {};
+  _skip() { };
 
-NullType.prototype._write = function (tap, val) {
-  if (val !== null) {
-    throwInvalidError(val, this);
-  }
-};
+  _write(tap, val) {
+    if (val !== null) {
+      throwInvalidError(val, this);
+    }
+  };
 
-NullType.prototype._match = function () { return 0; };
+  _match() { return 0; };
+}
+
 
 NullType.prototype.compare = NullType.prototype._match;
 
@@ -819,66 +825,71 @@ NullType.prototype.typeName = 'null';
 NullType.prototype.random = NullType.prototype._read;
 
 /** Booleans. */
-function BooleanType() { PrimitiveType.call(this); }
-util.inherits(BooleanType, PrimitiveType);
+class BooleanType extends PrimitiveType {
+  constructor() { super(); }
 
-BooleanType.prototype._check = function (val, flags, hook) {
-  var b = typeof val == 'boolean';
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = typeof val == 'boolean';
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-BooleanType.prototype._read = function (tap) { return tap.readBoolean(); };
+  _read(tap) { return tap.readBoolean(); };
 
-BooleanType.prototype._skip = function (tap) { tap.skipBoolean(); };
+  _skip(tap) { tap.skipBoolean(); };
 
-BooleanType.prototype._write = function (tap, val) {
-  if (typeof val != 'boolean') {
-    throwInvalidError(val, this);
-  }
-  tap.writeBoolean(val);
-};
+  _write(tap, val) {
+    if (typeof val != 'boolean') {
+      throwInvalidError(val, this);
+    }
+    tap.writeBoolean(val);
+  };
 
-BooleanType.prototype._match = function (tap1, tap2) {
-  return tap1.matchBoolean(tap2);
-};
+  _match(tap1, tap2) {
+    return tap1.matchBoolean(tap2);
+  };
+
+  random() { return RANDOM.nextBoolean(); };
+}
+
 
 BooleanType.prototype.typeName = 'boolean';
 
-BooleanType.prototype.random = function () { return RANDOM.nextBoolean(); };
 
 /** Integers. */
-function IntType() { PrimitiveType.call(this); }
-util.inherits(IntType, PrimitiveType);
+class IntType extends PrimitiveType {
+  constructor() { super(); }
 
-IntType.prototype._check = function (val, flags, hook) {
-  var b = val === (val | 0);
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = val === (val | 0);
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-IntType.prototype._read = function (tap) { return tap.readInt(); };
+  _read(tap) { return tap.readInt(); };
 
-IntType.prototype._skip = function (tap) { tap.skipInt(); };
+  _skip(tap) { tap.skipInt(); };
 
-IntType.prototype._write = function (tap, val) {
-  if (val !== (val | 0)) {
-    throwInvalidError(val, this);
-  }
-  tap.writeInt(val);
-};
+  _write(tap, val) {
+    if (val !== (val | 0)) {
+      throwInvalidError(val, this);
+    }
+    tap.writeInt(val);
+  };
 
-IntType.prototype._match = function (tap1, tap2) {
-  return tap1.matchInt(tap2);
-};
+  _match(tap1, tap2) {
+    return tap1.matchInt(tap2);
+  };
+  random() { return RANDOM.nextInt(1000) | 0; };
+}
+
 
 IntType.prototype.typeName = 'int';
 
-IntType.prototype.random = function () { return RANDOM.nextInt(1000) | 0; };
 
 /**
  * Longs.
@@ -888,207 +899,213 @@ IntType.prototype.random = function () { return RANDOM.nextInt(1000) | 0; };
  * and throws rather than potentially silently change the data. See `__with` or
  * `AbstractLongType` below for a way to implement a custom long type.
  */
-function LongType() { PrimitiveType.call(this); }
-util.inherits(LongType, PrimitiveType);
+class LongType extends PrimitiveType {
+  constructor() { super(); }
 
-LongType.prototype._check = function (val, flags, hook) {
-  var b = typeof val == 'number' && val % 1 === 0 && isSafeLong(val);
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = typeof val == 'number' && val % 1 === 0 && isSafeLong(val);
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-LongType.prototype._read = function (tap) {
-  var n = tap.readLong();
-  if (!isSafeLong(n)) {
-    throw new Error('potential precision loss');
-  }
-  return n;
-};
+  _read(tap) {
+    var n = tap.readLong();
+    if (!isSafeLong(n)) {
+      throw new Error('potential precision loss');
+    }
+    return n;
+  };
 
-LongType.prototype._skip = function (tap) { tap.skipLong(); };
+  _skip(tap) { tap.skipLong(); };
 
-LongType.prototype._write = function (tap, val) {
-  if (typeof val != 'number' || val % 1 || !isSafeLong(val)) {
-    throwInvalidError(val, this);
-  }
-  tap.writeLong(val);
-};
+  _write(tap, val) {
+    if (typeof val != 'number' || val % 1 || !isSafeLong(val)) {
+      throwInvalidError(val, this);
+    }
+    tap.writeLong(val);
+  };
 
-LongType.prototype._match = function (tap1, tap2) {
-  return tap1.matchLong(tap2);
-};
+  _match(tap1, tap2) {
+    return tap1.matchLong(tap2);
+  };
 
-LongType.prototype._update = function (resolver, type) {
-  switch (type.typeName) {
-    case 'int':
-      resolver._read = type._read;
-      break;
-    case 'abstract:long':
-    case 'long':
-      resolver._read = this._read; // In case `type` is an `AbstractLongType`.
-  }
-};
+  _update(resolver, type) {
+    switch (type.typeName) {
+      case 'int':
+        resolver._read = type._read;
+        break;
+      case 'abstract:long':
+      case 'long':
+        resolver._read = this._read; // In case `type` is an `AbstractLongType`.
+    }
+  };
+
+  random() { return RANDOM.nextInt(); };
+
+  static __with(methods, noUnpack) {
+    methods = methods || {}; // Will give a more helpful error message.
+    // We map some of the methods to a different name to be able to intercept
+    // their input and output (otherwise we wouldn't be able to perform any
+    // unpacking logic, and the type wouldn't work when nested).
+    var mapping = {
+      toBuffer: '_toBuffer',
+      fromBuffer: '_fromBuffer',
+      fromJSON: '_fromJSON',
+      toJSON: '_toJSON',
+      isValid: '_isValid',
+      compare: 'compare'
+    };
+    var type = new AbstractLongType(noUnpack);
+    Object.keys(mapping).forEach(function (name) {
+      if (methods[name] === undefined) {
+        throw new Error(`missing method implementation: ${name}`);
+      }
+      type[mapping[name]] = methods[name];
+    });
+    return Object.freeze(type);
+  };
+}
 
 LongType.prototype.typeName = 'long';
 
-LongType.prototype.random = function () { return RANDOM.nextInt(); };
 
-LongType.__with = function (methods, noUnpack) {
-  methods = methods || {}; // Will give a more helpful error message.
-  // We map some of the methods to a different name to be able to intercept
-  // their input and output (otherwise we wouldn't be able to perform any
-  // unpacking logic, and the type wouldn't work when nested).
-  var mapping = {
-    toBuffer: '_toBuffer',
-    fromBuffer: '_fromBuffer',
-    fromJSON: '_fromJSON',
-    toJSON: '_toJSON',
-    isValid: '_isValid',
-    compare: 'compare'
-  };
-  var type = new AbstractLongType(noUnpack);
-  Object.keys(mapping).forEach(function (name) {
-    if (methods[name] === undefined) {
-      throw new Error(f('missing method implementation: %s', name));
-    }
-    type[mapping[name]] = methods[name];
-  });
-  return Object.freeze(type);
-};
 
 /** Floats. */
-function FloatType() { PrimitiveType.call(this); }
-util.inherits(FloatType, PrimitiveType);
+class FloatType extends PrimitiveType {
+  constructor() { super(); }
 
-FloatType.prototype._check = function (val, flags, hook) {
-  var b = typeof val == 'number';
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = typeof val == 'number';
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-FloatType.prototype._read = function (tap) { return tap.readFloat(); };
+  _read(tap) { return tap.readFloat(); };
 
-FloatType.prototype._skip = function (tap) { tap.skipFloat(); };
+  _skip(tap) { tap.skipFloat(); };
 
-FloatType.prototype._write = function (tap, val) {
-  if (typeof val != 'number') {
-    throwInvalidError(val, this);
-  }
-  tap.writeFloat(val);
-};
+  _write(tap, val) {
+    if (typeof val != 'number') {
+      throwInvalidError(val, this);
+    }
+    tap.writeFloat(val);
+  };
 
-FloatType.prototype._match = function (tap1, tap2) {
-  return tap1.matchFloat(tap2);
-};
+  _match(tap1, tap2) {
+    return tap1.matchFloat(tap2);
+  };
 
-FloatType.prototype._update = function (resolver, type) {
-  switch (type.typeName) {
-    case 'float':
-    case 'int':
-      resolver._read = type._read;
-      break;
-    case 'abstract:long':
-    case 'long':
-      // No need to worry about precision loss here since we're always rounding
-      // to float anyway.
-      resolver._read = function (tap) { return tap.readLong(); };
-  }
-};
+  _update(resolver, type) {
+    switch (type.typeName) {
+      case 'float':
+      case 'int':
+        resolver._read = type._read;
+        break;
+      case 'abstract:long':
+      case 'long':
+        // No need to worry about precision loss here since we're always rounding
+        // to float anyway.
+        resolver._read = function (tap) { return tap.readLong(); };
+    }
+  };
+  random() { return RANDOM.nextFloat(1e3); };
+}
 
 FloatType.prototype.typeName = 'float';
 
-FloatType.prototype.random = function () { return RANDOM.nextFloat(1e3); };
-
 /** Doubles. */
-function DoubleType() { PrimitiveType.call(this); }
-util.inherits(DoubleType, PrimitiveType);
+class DoubleType extends PrimitiveType {
+  constructor() { super(); }
 
-DoubleType.prototype._check = function (val, flags, hook) {
-  var b = typeof val == 'number';
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = typeof val == 'number';
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-DoubleType.prototype._read = function (tap) { return tap.readDouble(); };
+  _read(tap) { return tap.readDouble(); };
 
-DoubleType.prototype._skip = function (tap) { tap.skipDouble(); };
+  _skip(tap) { tap.skipDouble(); };
 
-DoubleType.prototype._write = function (tap, val) {
-  if (typeof val != 'number') {
-    throwInvalidError(val, this);
-  }
-  tap.writeDouble(val);
-};
+  _write(tap, val) {
+    if (typeof val != 'number') {
+      throwInvalidError(val, this);
+    }
+    tap.writeDouble(val);
+  };
 
-DoubleType.prototype._match = function (tap1, tap2) {
-  return tap1.matchDouble(tap2);
-};
+  _match(tap1, tap2) {
+    return tap1.matchDouble(tap2);
+  };
 
-DoubleType.prototype._update = function (resolver, type) {
-  switch (type.typeName) {
-    case 'double':
-    case 'float':
-    case 'int':
-      resolver._read = type._read;
-      break;
-    case 'abstract:long':
-    case 'long':
-      // Similar to inside `FloatType`, no need to worry about precision loss
-      // here since we're always rounding to double anyway.
-      resolver._read = function (tap) { return tap.readLong(); };
-  }
-};
+  _update(resolver, type) {
+    switch (type.typeName) {
+      case 'double':
+      case 'float':
+      case 'int':
+        resolver._read = type._read;
+        break;
+      case 'abstract:long':
+      case 'long':
+        // Similar to inside `FloatType`, no need to worry about precision loss
+        // here since we're always rounding to double anyway.
+        resolver._read = function (tap) { return tap.readLong(); };
+    }
+  };
+  random() { return RANDOM.nextFloat(); };
+}
 
 DoubleType.prototype.typeName = 'double';
 
-DoubleType.prototype.random = function () { return RANDOM.nextFloat(); };
 
 /** Strings. */
-function StringType() { PrimitiveType.call(this); }
-util.inherits(StringType, PrimitiveType);
+class StringType extends PrimitiveType {
+  constructor() { PrimitiveType.call(this); }
 
-StringType.prototype._check = function (val, flags, hook) {
-  var b = typeof val == 'string';
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
+  _check(val, flags, hook) {
+    var b = typeof val == 'string';
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-StringType.prototype._read = function (tap) { return tap.readString(); };
+  _read(tap) { return tap.readString(); };
 
-StringType.prototype._skip = function (tap) { tap.skipString(); };
+  _skip(tap) { tap.skipString(); };
 
-StringType.prototype._write = function (tap, val) {
-  if (typeof val != 'string') {
-    throwInvalidError(val, this);
-  }
-  tap.writeString(val);
-};
+  _write(tap, val) {
+    if (typeof val != 'string') {
+      throwInvalidError(val, this);
+    }
+    tap.writeString(val);
+  };
 
-StringType.prototype._match = function (tap1, tap2) {
-  return tap1.matchString(tap2);
-};
+  _match(tap1, tap2) {
+    return tap1.matchString(tap2);
+  };
 
-StringType.prototype._update = function (resolver, type) {
-  switch (type.typeName) {
-    case 'bytes':
-    case 'string':
-      resolver._read = this._read;
-  }
-};
+  _update(resolver, type) {
+    switch (type.typeName) {
+      case 'bytes':
+      case 'string':
+        resolver._read = this._read;
+    }
+  };
+
+  random() {
+    return RANDOM.nextString(RANDOM.nextInt(32));
+  };
+}
 
 StringType.prototype.typeName = 'string';
 
-StringType.prototype.random = function () {
-  return RANDOM.nextString(RANDOM.nextInt(32));
-};
 
 /**
  * Bytes.
@@ -1099,119 +1116,124 @@ StringType.prototype.random = function () {
  *
  * Note the coercion in `_copy`.
  */
-function BytesType() { PrimitiveType.call(this); }
-util.inherits(BytesType, PrimitiveType);
-
-BytesType.prototype._check = function (val, flags, hook) {
-  var b = Buffer.isBuffer(val);
-  if (!b && hook) {
-    hook(val, this);
+class BytesType extends PrimitiveType {
+  constructor() {
+    super();
   }
-  return b;
-};
 
-BytesType.prototype._read = function (tap) { return tap.readBytes(); };
+  _check(val, flags, hook) {
+    var b = Buffer.isBuffer(val);
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
 
-BytesType.prototype._skip = function (tap) { tap.skipBytes(); };
+  _read(tap) { return tap.readBytes(); };
 
-BytesType.prototype._write = function (tap, val) {
-  if (!Buffer.isBuffer(val)) {
-    throwInvalidError(val, this);
-  }
-  tap.writeBytes(val);
-};
+  _skip(tap) { tap.skipBytes(); };
 
-BytesType.prototype._match = function (tap1, tap2) {
-  return tap1.matchBytes(tap2);
-};
+  _write(tap, val) {
+    if (!Buffer.isBuffer(val)) {
+      throwInvalidError(val, this);
+    }
+    tap.writeBytes(val);
+  };
+
+  _match(tap1, tap2) {
+    return tap1.matchBytes(tap2);
+  };
+
+  _copy(obj, opts) {
+    var buf;
+    switch ((opts && opts.coerce) | 0) {
+      case 3: // Coerce buffers to strings.
+        this._check(obj, undefined, throwInvalidError);
+        return obj.toString('binary');
+      case 2: // Coerce strings to buffers.
+        if (typeof obj != 'string') {
+          throw new Error(`cannot coerce to buffer: ${JSON.stringify(obj)}`);
+        }
+        buf = utils.bufferFrom(obj, 'binary');
+        this._check(buf, undefined, throwInvalidError);
+        return buf;
+      case 1: // Coerce buffer JSON representation to buffers.
+        if (!isJsonBuffer(obj)) {
+          throw new Error(`cannot coerce to buffer: ${JSON.stringify(obj)}`);
+        }
+        buf = utils.bufferFrom(obj.data);
+        this._check(buf, undefined, throwInvalidError);
+        return buf;
+      default: // Copy buffer.
+        this._check(obj, undefined, throwInvalidError);
+        return utils.bufferFrom(obj);
+    }
+  };
+
+  random() {
+    return RANDOM.nextBuffer(RANDOM.nextInt(32));
+  };
+}
+
 
 BytesType.prototype._update = StringType.prototype._update;
-
-BytesType.prototype._copy = function (obj, opts) {
-  var buf;
-  switch ((opts && opts.coerce) | 0) {
-    case 3: // Coerce buffers to strings.
-      this._check(obj, undefined, throwInvalidError);
-      return obj.toString('binary');
-    case 2: // Coerce strings to buffers.
-      if (typeof obj != 'string') {
-        throw new Error(f('cannot coerce to buffer: %j', obj));
-      }
-      buf = utils.bufferFrom(obj, 'binary');
-      this._check(buf, undefined, throwInvalidError);
-      return buf;
-    case 1: // Coerce buffer JSON representation to buffers.
-      if (!isJsonBuffer(obj)) {
-        throw new Error(f('cannot coerce to buffer: %j', obj));
-      }
-      buf = utils.bufferFrom(obj.data);
-      this._check(buf, undefined, throwInvalidError);
-      return buf;
-    default: // Copy buffer.
-      this._check(obj, undefined, throwInvalidError);
-      return utils.bufferFrom(obj);
-  }
-};
-
 BytesType.prototype.compare = Buffer.compare;
-
 BytesType.prototype.typeName = 'bytes';
 
-BytesType.prototype.random = function () {
-  return RANDOM.nextBuffer(RANDOM.nextInt(32));
-};
 
 /** Base "abstract" Avro union type. */
-function UnionType(schema, opts) {
-  Type.call(this);
+class UnionType extends Type {
+  constructor(schema, opts) {
+    super();
 
-  if (!Array.isArray(schema)) {
-    throw new Error(f('non-array union schema: %j', schema));
-  }
-  if (!schema.length) {
-    throw new Error('empty union');
-  }
-  this.types = Object.freeze(schema.map(function (obj) {
-    return Type.forSchema(obj, opts);
-  }));
+    if (!Array.isArray(schema)) {
+      throw new Error(`non-array union schema: ${JSON.stringify(schema)}`);
+    }
+    if (!schema.length) {
+      throw new Error('empty union');
+    }
+    this.types = Object.freeze(schema.map(function (obj) {
+      return Type.forSchema(obj, opts);
+    }));
 
-  this._branchIndices = {};
-  this.types.forEach(function (type, i) {
-    if (Type.isType(type, 'union')) {
-      throw new Error('unions cannot be directly nested');
+    this._branchIndices = {};
+    this.types.forEach(function (type, i) {
+      if (Type.isType(type, 'union')) {
+        throw new Error('unions cannot be directly nested');
+      }
+      var branch = type.branchName;
+      if (this._branchIndices[branch] !== undefined) {
+        throw new Error(`duplicate union branch name: ${JSON.stringify(branch)}`);
+      }
+      this._branchIndices[branch] = i;
+    }, this);
+  }
+
+  _branchConstructor() {
+    throw new Error('unions cannot be directly wrapped');
+  };
+
+  _skip(tap) {
+    this.types[tap.readLong()]._skip(tap);
+  };
+
+  _match(tap1, tap2) {
+    var n1 = tap1.readLong();
+    var n2 = tap2.readLong();
+    if (n1 === n2) {
+      return this.types[n1]._match(tap1, tap2);
+    } else {
+      return n1 < n2 ? -1 : 1;
     }
-    var branch = type.branchName;
-    if (this._branchIndices[branch] !== undefined) {
-      throw new Error(f('duplicate union branch name: %j', branch));
-    }
-    this._branchIndices[branch] = i;
-  }, this);
+  };
+
+  _deref(schema, opts) {
+    return this.types.map(function (t) { return t._attrs(opts); });
+  };
+
+  getTypes() { return this.types; };
 }
-util.inherits(UnionType, Type);
 
-UnionType.prototype._branchConstructor = function () {
-  throw new Error('unions cannot be directly wrapped');
-};
-
-UnionType.prototype._skip = function (tap) {
-  this.types[tap.readLong()]._skip(tap);
-};
-
-UnionType.prototype._match = function (tap1, tap2) {
-  var n1 = tap1.readLong();
-  var n2 = tap2.readLong();
-  if (n1 === n2) {
-    return this.types[n1]._match(tap1, tap2);
-  } else {
-    return n1 < n2 ? -1 : 1;
-  }
-};
-
-UnionType.prototype._deref = function (schema, opts) {
-  return this.types.map(function (t) { return t._attrs(opts); });
-};
-
-UnionType.prototype.getTypes = function () { return this.types; };
 
 /**
  * "Natural" union type.
@@ -1232,180 +1254,182 @@ UnionType.prototype.getTypes = function () { return this.types; };
  * + `array`
  * + `map`, `record`
  */
-function UnwrappedUnionType(schema, opts) {
-  UnionType.call(this, schema, opts);
+class UnwrappedUnionType extends UnionType {
+  constructor(schema, opts) {
+    super(schema, opts);
 
-  this._dynamicBranches = null;
-  this._bucketIndices = {};
-  this.types.forEach(function (type, index) {
-    if (Type.isType(type, 'abstract', 'logical')) {
-      if (!this._dynamicBranches) {
-        this._dynamicBranches = [];
-      }
-      this._dynamicBranches.push({index: index, type: type});
-    } else {
-      var bucket = getTypeBucket(type);
-      if (this._bucketIndices[bucket] !== undefined) {
-        throw new Error(f('ambiguous unwrapped union: %j', this));
-      }
-      this._bucketIndices[bucket] = index;
-    }
-  }, this);
-
-  Object.freeze(this);
-}
-util.inherits(UnwrappedUnionType, UnionType);
-
-UnwrappedUnionType.prototype._getIndex = function (val) {
-  var index = this._bucketIndices[getValueBucket(val)];
-  if (this._dynamicBranches) {
-    // Slower path, we must run the value through all branches.
-    index = this._getBranchIndex(val, index);
-  }
-  return index;
-};
-
-UnwrappedUnionType.prototype._getBranchIndex = function (any, index) {
-  var logicalBranches = this._dynamicBranches;
-  var i, l, branch;
-  for (i = 0, l = logicalBranches.length; i < l; i++) {
-    branch = logicalBranches[i];
-    if (branch.type._check(any)) {
-      if (index === undefined) {
-        index = branch.index;
+    this._dynamicBranches = null;
+    this._bucketIndices = {};
+    this.types.forEach(function (type, index) {
+      if (Type.isType(type, 'abstract', 'logical')) {
+        if (!this._dynamicBranches) {
+          this._dynamicBranches = [];
+        }
+        this._dynamicBranches.push({ index: index, type: type });
       } else {
-        // More than one branch matches the value so we aren't guaranteed to
-        // infer the correct type. We throw rather than corrupt data. This can
-        // be fixed by "tightening" the logical types.
-        throw new Error('ambiguous conversion');
+        var bucket = getTypeBucket(type);
+        if (this._bucketIndices[bucket] !== undefined) {
+          throw new Error(`ambiguous unwrapped union: ${JSON.stringify(this)}`);
+        }
+        this._bucketIndices[bucket] = index;
+      }
+    }, this);
+
+    Object.freeze(this);
+  }
+
+  _getIndex(val) {
+    var index = this._bucketIndices[getValueBucket(val)];
+    if (this._dynamicBranches) {
+      // Slower path, we must run the value through all branches.
+      index = this._getBranchIndex(val, index);
+    }
+    return index;
+  };
+
+  _getBranchIndex(any, index) {
+    var logicalBranches = this._dynamicBranches;
+    var i, l, branch;
+    for (i = 0, l = logicalBranches.length; i < l; i++) {
+      branch = logicalBranches[i];
+      if (branch.type._check(any)) {
+        if (index === undefined) {
+          index = branch.index;
+        } else {
+          // More than one branch matches the value so we aren't guaranteed to
+          // infer the correct type. We throw rather than corrupt data. This can
+          // be fixed by "tightening" the logical types.
+          throw new Error('ambiguous conversion');
+        }
       }
     }
-  }
-  return index;
-};
+    return index;
+  };
 
-UnwrappedUnionType.prototype._check = function (val, flags, hook, path) {
-  var index = this._getIndex(val);
-  var b = index !== undefined;
-  if (b) {
-    return this.types[index]._check(val, flags, hook, path);
-  }
-  if (hook) {
-    hook(val, this);
-  }
-  return b;
-};
-
-UnwrappedUnionType.prototype._read = function (tap) {
-  var index = tap.readLong();
-  var branchType = this.types[index];
-  if (branchType) {
-    return branchType._read(tap);
-  } else {
-    throw new Error(f('invalid union index: %s', index));
-  }
-};
-
-UnwrappedUnionType.prototype._write = function (tap, val) {
-  var index = this._getIndex(val);
-  if (index === undefined) {
-    throwInvalidError(val, this);
-  }
-  tap.writeLong(index);
-  if (val !== null) {
-    this.types[index]._write(tap, val);
-  }
-};
-
-UnwrappedUnionType.prototype._update = function (resolver, type, opts) {
-  // jshint -W083
-  // (The loop exits after the first function is created.)
-  var i, l, typeResolver;
-  for (i = 0, l = this.types.length; i < l; i++) {
-    try {
-      typeResolver = this.types[i].createResolver(type, opts);
-    } catch (err) {
-      continue;
+  _check(val, flags, hook, path) {
+    var index = this._getIndex(val);
+    var b = index !== undefined;
+    if (b) {
+      return this.types[index]._check(val, flags, hook, path);
     }
-    resolver._read = function (tap) { return typeResolver._read(tap); };
-    return;
-  }
-};
-
-UnwrappedUnionType.prototype._copy = function (val, opts) {
-  var coerce = opts && opts.coerce | 0;
-  var wrap = opts && opts.wrap | 0;
-  var index;
-  if (wrap === 2) {
-    // We are parsing a default, so always use the first branch's type.
-    index = 0;
-  } else {
-    switch (coerce) {
-      case 1:
-        // Using the `coerceBuffers` option can cause corruption and erroneous
-        // failures with unwrapped unions (in rare cases when the union also
-        // contains a record which matches a buffer's JSON representation).
-        if (isJsonBuffer(val) && this._bucketIndices.buffer !== undefined) {
-          index = this._bucketIndices.buffer;
-        } else {
-          index = this._getIndex(val);
-        }
-        break;
-      case 2:
-        // Decoding from JSON, we must unwrap the value.
-        if (val === null) {
-          index = this._bucketIndices['null'];
-        } else if (typeof val === 'object') {
-          var keys = Object.keys(val);
-          if (keys.length === 1) {
-            index = this._branchIndices[keys[0]];
-            val = val[keys[0]];
-          }
-        }
-        break;
-      default:
-        index = this._getIndex(val);
+    if (hook) {
+      hook(val, this);
     }
+    return b;
+  };
+
+  _read(tap) {
+    var index = tap.readLong();
+    var branchType = this.types[index];
+    if (branchType) {
+      return branchType._read(tap);
+    } else {
+      throw new Error(`invalid union index: ${index}`);
+    }
+  };
+
+  _write(tap, val) {
+    var index = this._getIndex(val);
     if (index === undefined) {
       throwInvalidError(val, this);
     }
-  }
-  var type = this.types[index];
-  if (val === null || wrap === 3) {
-    return type._copy(val, opts);
-  } else {
-    switch (coerce) {
-      case 3:
-        // Encoding to JSON, we wrap the value.
-        var obj = {};
-        obj[type.branchName] = type._copy(val, opts);
-        return obj;
-      default:
-        return type._copy(val, opts);
+    tap.writeLong(index);
+    if (val !== null) {
+      this.types[index]._write(tap, val);
     }
-  }
-};
+  };
 
-UnwrappedUnionType.prototype.compare = function (val1, val2) {
-  var index1 = this._getIndex(val1);
-  var index2 = this._getIndex(val2);
-  if (index1 === undefined) {
-    throwInvalidError(val1, this);
-  } else if (index2 === undefined) {
-    throwInvalidError(val2, this);
-  } else if (index1 === index2) {
-    return this.types[index1].compare(val1, val2);
-  } else {
-    return utils.compare(index1, index2);
-  }
-};
+  _update(resolver, type, opts) {
+    // jshint -W083
+    // (The loop exits after the first function is created.)
+    var i, l, typeResolver;
+    for (i = 0, l = this.types.length; i < l; i++) {
+      try {
+        typeResolver = this.types[i].createResolver(type, opts);
+      } catch (err) {
+        continue;
+      }
+      resolver._read = function (tap) { return typeResolver._read(tap); };
+      return;
+    }
+  };
+
+  _copy(val, opts) {
+    var coerce = opts && opts.coerce | 0;
+    var wrap = opts && opts.wrap | 0;
+    var index;
+    if (wrap === 2) {
+      // We are parsing a default, so always use the first branch's type.
+      index = 0;
+    } else {
+      switch (coerce) {
+        case 1:
+          // Using the `coerceBuffers` option can cause corruption and erroneous
+          // failures with unwrapped unions (in rare cases when the union also
+          // contains a record which matches a buffer's JSON representation).
+          if (isJsonBuffer(val) && this._bucketIndices.buffer !== undefined) {
+            index = this._bucketIndices.buffer;
+          } else {
+            index = this._getIndex(val);
+          }
+          break;
+        case 2:
+          // Decoding from JSON, we must unwrap the value.
+          if (val === null) {
+            index = this._bucketIndices['null'];
+          } else if (typeof val === 'object') {
+            var keys = Object.keys(val);
+            if (keys.length === 1) {
+              index = this._branchIndices[keys[0]];
+              val = val[keys[0]];
+            }
+          }
+          break;
+        default:
+          index = this._getIndex(val);
+      }
+      if (index === undefined) {
+        throwInvalidError(val, this);
+      }
+    }
+    var type = this.types[index];
+    if (val === null || wrap === 3) {
+      return type._copy(val, opts);
+    } else {
+      switch (coerce) {
+        case 3:
+          // Encoding to JSON, we wrap the value.
+          var obj = {};
+          obj[type.branchName] = type._copy(val, opts);
+          return obj;
+        default:
+          return type._copy(val, opts);
+      }
+    }
+  };
+
+  compare(val1, val2) {
+    var index1 = this._getIndex(val1);
+    var index2 = this._getIndex(val2);
+    if (index1 === undefined) {
+      throwInvalidError(val1, this);
+    } else if (index2 === undefined) {
+      throwInvalidError(val2, this);
+    } else if (index1 === index2) {
+      return this.types[index1].compare(val1, val2);
+    } else {
+      return utils.compare(index1, index2);
+    }
+  };
+
+  random() {
+    var index = RANDOM.nextInt(this.types.length);
+    return this.types[index].random();
+  };
+}
 
 UnwrappedUnionType.prototype.typeName = 'union:unwrapped';
 
-UnwrappedUnionType.prototype.random = function () {
-  var index = RANDOM.nextInt(this.types.length);
-  return this.types[index].random();
-};
 
 /**
  * Compatible union type.
@@ -1427,180 +1451,181 @@ UnwrappedUnionType.prototype.random = function () {
  *   longer be valid records (making it inconvenient to do simple things like
  *   creating new records).
  */
-function WrappedUnionType(schema, opts) {
-  UnionType.call(this, schema, opts);
-  Object.freeze(this);
-}
-util.inherits(WrappedUnionType, UnionType);
-
-WrappedUnionType.prototype._check = function (val, flags, hook, path) {
-  var b = false;
-  if (val === null) {
-    // Shortcut type lookup in this case.
-    b = this._branchIndices['null'] !== undefined;
-  } else if (typeof val == 'object') {
-    var keys = Object.keys(val);
-    if (keys.length === 1) {
-      // We require a single key here to ensure that writes are correct and
-      // efficient as soon as a record passes this check.
-      var name = keys[0];
-      var index = this._branchIndices[name];
-      if (index !== undefined) {
-        if (hook) {
-          // Slow path.
-          path.push(name);
-          b = this.types[index]._check(val[name], flags, hook, path);
-          path.pop();
-          return b;
-        } else {
-          return this.types[index]._check(val[name], flags);
-        }
-      }
-    }
-  }
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
-
-WrappedUnionType.prototype._read = function (tap) {
-  var type = this.types[tap.readLong()];
-  if (!type) {
-    throw new Error(f('invalid union index'));
-  }
-  var Branch = type._branchConstructor;
-  if (Branch === null) {
-    return null;
-  } else {
-    return new Branch(type._read(tap));
-  }
-};
-
-WrappedUnionType.prototype._write = function (tap, val) {
-  var index, keys, name;
-  if (val === null) {
-    index = this._branchIndices['null'];
-    if (index === undefined) {
-      throwInvalidError(val, this);
-    }
-    tap.writeLong(index);
-  } else {
-    keys = Object.keys(val);
-    if (keys.length === 1) {
-      name = keys[0];
-      index = this._branchIndices[name];
-    }
-    if (index === undefined) {
-      throwInvalidError(val, this);
-    }
-    tap.writeLong(index);
-    this.types[index]._write(tap, val[name]);
-  }
-};
-
-WrappedUnionType.prototype._update = function (resolver, type, opts) {
-  // jshint -W083
-  // (The loop exits after the first function is created.)
-  var i, l, typeResolver, Branch;
-  for (i = 0, l = this.types.length; i < l; i++) {
-    try {
-      typeResolver = this.types[i].createResolver(type, opts);
-    } catch (err) {
-      continue;
-    }
-    Branch = this.types[i]._branchConstructor;
-    if (Branch) {
-      resolver._read = function (tap) {
-        return new Branch(typeResolver._read(tap));
-      };
-    } else {
-      resolver._read = function () { return null; };
-    }
-    return;
-  }
-};
-
-WrappedUnionType.prototype._copy = function (val, opts) {
-  var wrap = opts && opts.wrap | 0;
-  if (wrap === 2) {
-    var firstType = this.types[0];
-    // Promote into first type (used for schema defaults).
-    if (val === null && firstType.typeName === 'null') {
-      return null;
-    }
-    return new firstType._branchConstructor(firstType._copy(val, opts));
-  }
-  if (val === null && this._branchIndices['null'] !== undefined) {
-    return null;
+class WrappedUnionType extends UnionType {
+  constructor(schema, opts) {
+    super(schema, opts);
+    Object.freeze(this);
   }
 
-  var i, l, obj;
-  if (typeof val == 'object') {
-    var keys = Object.keys(val);
-    if (keys.length === 1) {
-      var name = keys[0];
-      i = this._branchIndices[name];
-      if (i === undefined && opts.qualifyNames) {
-        // We are a bit more flexible than in `_check` here since we have
-        // to deal with other serializers being less strict, so we fall
-        // back to looking up unqualified names.
-        var j, type;
-        for (j = 0, l = this.types.length; j < l; j++) {
-          type = this.types[j];
-          if (type.name && name === unqualify(type.name)) {
-            i = j;
-            break;
+  _check(val, flags, hook, path) {
+    var b = false;
+    if (val === null) {
+      // Shortcut type lookup in this case.
+      b = this._branchIndices['null'] !== undefined;
+    } else if (typeof val == 'object') {
+      var keys = Object.keys(val);
+      if (keys.length === 1) {
+        // We require a single key here to ensure that writes are correct and
+        // efficient as soon as a record passes this check.
+        var name = keys[0];
+        var index = this._branchIndices[name];
+        if (index !== undefined) {
+          if (hook) {
+            // Slow path.
+            path.push(name);
+            b = this.types[index]._check(val[name], flags, hook, path);
+            path.pop();
+            return b;
+          } else {
+            return this.types[index]._check(val[name], flags);
           }
         }
       }
-      if (i !== undefined) {
-        obj = this.types[i]._copy(val[name], opts);
-      }
     }
-  }
-  if (wrap === 1 && obj === undefined) {
-    // Try promoting into first match (convenience, slow).
-    i = 0;
-    l = this.types.length;
-    while (i < l && obj === undefined) {
-      try {
-        obj = this.types[i]._copy(val, opts);
-      } catch (err) {
-        i++;
-      }
+    if (!b && hook) {
+      hook(val, this);
     }
-  }
-  if (obj !== undefined) {
-    return wrap === 3 ? obj : new this.types[i]._branchConstructor(obj);
-  }
-  throwInvalidError(val, this);
-};
+    return b;
+  };
 
-WrappedUnionType.prototype.compare = function (val1, val2) {
-  var name1 = val1 === null ? 'null' : Object.keys(val1)[0];
-  var name2 = val2 === null ? 'null' : Object.keys(val2)[0];
-  var index = this._branchIndices[name1];
-  if (name1 === name2) {
-    return name1 === 'null' ?
-      0 :
-      this.types[index].compare(val1[name1], val2[name1]);
-  } else {
-    return utils.compare(index, this._branchIndices[name2]);
-  }
-};
+  _read(tap) {
+    var type = this.types[tap.readLong()];
+    if (!type) {
+      throw new Error(`invalid union index`);
+    }
+    var Branch = type._branchConstructor;
+    if (Branch === null) {
+      return null;
+    } else {
+      return new Branch(type._read(tap));
+    }
+  };
+
+  _write(tap, val) {
+    var index, keys, name;
+    if (val === null) {
+      index = this._branchIndices['null'];
+      if (index === undefined) {
+        throwInvalidError(val, this);
+      }
+      tap.writeLong(index);
+    } else {
+      keys = Object.keys(val);
+      if (keys.length === 1) {
+        name = keys[0];
+        index = this._branchIndices[name];
+      }
+      if (index === undefined) {
+        throwInvalidError(val, this);
+      }
+      tap.writeLong(index);
+      this.types[index]._write(tap, val[name]);
+    }
+  };
+
+  _update(resolver, type, opts) {
+    // jshint -W083
+    // (The loop exits after the first function is created.)
+    var i, l, typeResolver, Branch;
+    for (i = 0, l = this.types.length; i < l; i++) {
+      try {
+        typeResolver = this.types[i].createResolver(type, opts);
+      } catch (err) {
+        continue;
+      }
+      Branch = this.types[i]._branchConstructor;
+      if (Branch) {
+        resolver._read = function (tap) {
+          return new Branch(typeResolver._read(tap));
+        };
+      } else {
+        resolver._read = function () { return null; };
+      }
+      return;
+    }
+  };
+
+  _copy(val, opts) {
+    var wrap = opts && opts.wrap | 0;
+    if (wrap === 2) {
+      var firstType = this.types[0];
+      // Promote into first type (used for schema defaults).
+      if (val === null && firstType.typeName === 'null') {
+        return null;
+      }
+      return new firstType._branchConstructor(firstType._copy(val, opts));
+    }
+    if (val === null && this._branchIndices['null'] !== undefined) {
+      return null;
+    }
+
+    var i, l, obj;
+    if (typeof val == 'object') {
+      var keys = Object.keys(val);
+      if (keys.length === 1) {
+        var name = keys[0];
+        i = this._branchIndices[name];
+        if (i === undefined && opts.qualifyNames) {
+          // We are a bit more flexible than in `_check` here since we have
+          // to deal with other serializers being less strict, so we fall
+          // back to looking up unqualified names.
+          var j, type;
+          for (j = 0, l = this.types.length; j < l; j++) {
+            type = this.types[j];
+            if (type.name && name === unqualify(type.name)) {
+              i = j;
+              break;
+            }
+          }
+        }
+        if (i !== undefined) {
+          obj = this.types[i]._copy(val[name], opts);
+        }
+      }
+    }
+    if (wrap === 1 && obj === undefined) {
+      // Try promoting into first match (convenience, slow).
+      i = 0;
+      l = this.types.length;
+      while (i < l && obj === undefined) {
+        try {
+          obj = this.types[i]._copy(val, opts);
+        } catch (err) {
+          i++;
+        }
+      }
+    }
+    if (obj !== undefined) {
+      return wrap === 3 ? obj : new this.types[i]._branchConstructor(obj);
+    }
+    throwInvalidError(val, this);
+  };
+
+  compare(val1, val2) {
+    var name1 = val1 === null ? 'null' : Object.keys(val1)[0];
+    var name2 = val2 === null ? 'null' : Object.keys(val2)[0];
+    var index = this._branchIndices[name1];
+    if (name1 === name2) {
+      return name1 === 'null' ?
+        0 :
+        this.types[index].compare(val1[name1], val2[name1]);
+    } else {
+      return utils.compare(index, this._branchIndices[name2]);
+    }
+  };
+
+  random() {
+    var index = RANDOM.nextInt(this.types.length);
+    var type = this.types[index];
+    var Branch = type._branchConstructor;
+    if (!Branch) {
+      return null;
+    }
+    return new Branch(type.random());
+  };
+}
 
 WrappedUnionType.prototype.typeName = 'union:wrapped';
-
-WrappedUnionType.prototype.random = function () {
-  var index = RANDOM.nextInt(this.types.length);
-  var type = this.types[index];
-  var Branch = type._branchConstructor;
-  if (!Branch) {
-    return null;
-  }
-  return new Branch(type.random());
-};
 
 /**
  * Avro enum type.
@@ -1614,448 +1639,454 @@ WrappedUnionType.prototype.random = function () {
  * TypeScript `enum`s) by overriding the `EnumType` with a `LongType` (e.g. via
  * `parse`'s registry).
  */
-function EnumType(schema, opts) {
-  Type.call(this, schema, opts);
-  if (!Array.isArray(schema.symbols) || !schema.symbols.length) {
-    throw new Error(f('invalid enum symbols: %j', schema.symbols));
+class EnumType extends Type {
+  constructor(schema, opts) {
+    super(schema, opts);
+    if (!Array.isArray(schema.symbols) || !schema.symbols.length) {
+      throw new Error(`invalid enum symbols: ${JSON.stringify(schema.symbols)}`);
+    }
+    this.symbols = Object.freeze(schema.symbols.slice());
+    this._indices = {};
+    this.symbols.forEach(function (symbol, i) {
+      if (!isValidName(symbol)) {
+        throw new Error(`invalid ${this} symbol: ${JSON.stringify(symbol)}`);
+      }
+      if (this._indices[symbol] !== undefined) {
+        throw new Error(`duplicate ${this} symbol: ${JSON.stringify(symbol)}`);
+      }
+      this._indices[symbol] = i;
+    }, this);
+    this._branchConstructor = this._createBranchConstructor();
+    Object.freeze(this);
   }
-  this.symbols = Object.freeze(schema.symbols.slice());
-  this._indices = {};
-  this.symbols.forEach(function (symbol, i) {
-    if (!isValidName(symbol)) {
-      throw new Error(f('invalid %s symbol: %j', this, symbol));
+
+  _check(val, flags, hook) {
+    var b = this._indices[val] !== undefined;
+    if (!b && hook) {
+      hook(val, this);
     }
-    if (this._indices[symbol] !== undefined) {
-      throw new Error(f('duplicate %s symbol: %j', this, symbol));
+    return b;
+  };
+
+  _read(tap) {
+    var index = tap.readLong();
+    var symbol = this.symbols[index];
+    if (symbol === undefined) {
+      throw new Error(`invalid ${this.name} enum index: ${JSON.stringify(index)}`);
     }
-    this._indices[symbol] = i;
-  }, this);
-  this._branchConstructor = this._createBranchConstructor();
-  Object.freeze(this);
+    return symbol;
+  };
+
+  _skip(tap) { tap.skipLong(); };
+
+  _write(tap, val) {
+    var index = this._indices[val];
+    if (index === undefined) {
+      throwInvalidError(val, this);
+    }
+    tap.writeLong(index);
+  };
+
+  _match(tap1, tap2) {
+    return tap1.matchLong(tap2);
+  };
+
+  compare(val1, val2) {
+    return utils.compare(this._indices[val1], this._indices[val2]);
+  };
+
+  _update(resolver, type) {
+    var symbols = this.symbols;
+    if (
+      type.typeName === 'enum' &&
+      (!type.name || ~getAliases(this).indexOf(type.name)) &&
+      type.symbols.every(function (s) { return ~symbols.indexOf(s); })
+    ) {
+      resolver.symbols = type.symbols;
+      resolver._read = type._read;
+    }
+  };
+
+  _copy(val) {
+    this._check(val, undefined, throwInvalidError);
+    return val;
+  };
+
+  _deref(schema) {
+    schema.symbols = this.symbols;
+  };
+
+  getSymbols() { return this.symbols; };
+
+  random() {
+    return RANDOM.choice(this.symbols);
+  };
 }
-util.inherits(EnumType, Type);
 
-EnumType.prototype._check = function (val, flags, hook) {
-  var b = this._indices[val] !== undefined;
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
-
-EnumType.prototype._read = function (tap) {
-  var index = tap.readLong();
-  var symbol = this.symbols[index];
-  if (symbol === undefined) {
-    throw new Error(f('invalid %s enum index: %s', this.name, index));
-  }
-  return symbol;
-};
-
-EnumType.prototype._skip = function (tap) { tap.skipLong(); };
-
-EnumType.prototype._write = function (tap, val) {
-  var index = this._indices[val];
-  if (index === undefined) {
-    throwInvalidError(val, this);
-  }
-  tap.writeLong(index);
-};
-
-EnumType.prototype._match = function (tap1, tap2) {
-  return tap1.matchLong(tap2);
-};
-
-EnumType.prototype.compare = function (val1, val2) {
-  return utils.compare(this._indices[val1], this._indices[val2]);
-};
-
-EnumType.prototype._update = function (resolver, type) {
-  var symbols = this.symbols;
-  if (
-    type.typeName === 'enum' &&
-    (!type.name || ~getAliases(this).indexOf(type.name)) &&
-    type.symbols.every(function (s) { return ~symbols.indexOf(s); })
-  ) {
-    resolver.symbols = type.symbols;
-    resolver._read = type._read;
-  }
-};
-
-EnumType.prototype._copy = function (val) {
-  this._check(val, undefined, throwInvalidError);
-  return val;
-};
-
-EnumType.prototype._deref = function (schema) {
-  schema.symbols = this.symbols;
-};
-
-EnumType.prototype.getSymbols = function () { return this.symbols; };
 
 EnumType.prototype.typeName = 'enum';
 
-EnumType.prototype.random = function () {
-  return RANDOM.choice(this.symbols);
-};
 
 /** Avro fixed type. Represented simply as a `Buffer`. */
-function FixedType(schema, opts) {
-  Type.call(this, schema, opts);
-  if (schema.size !== (schema.size | 0) || schema.size < 1) {
-    throw new Error(f('invalid %s size', this.branchName));
+class FixedType extends Type {
+  constructor(schema, opts) {
+    super(schema, opts);
+    if (schema.size !== (schema.size | 0) || schema.size < 1) {
+      throw new Error(`invalid ${this.branchName} size`);
+    }
+    this.size = schema.size | 0;
+    this._branchConstructor = this._createBranchConstructor();
+    Object.freeze(this);
   }
-  this.size = schema.size | 0;
-  this._branchConstructor = this._createBranchConstructor();
-  Object.freeze(this);
+
+  _check(val, flags, hook) {
+    var b = Buffer.isBuffer(val) && val.length === this.size;
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
+
+  _read(tap) {
+    return tap.readFixed(this.size);
+  };
+
+  _skip(tap) {
+    tap.skipFixed(this.size);
+  };
+
+  _write(tap, val) {
+    if (!Buffer.isBuffer(val) || val.length !== this.size) {
+      throwInvalidError(val, this);
+    }
+    tap.writeFixed(val, this.size);
+  };
+
+  _match(tap1, tap2) {
+    return tap1.matchFixed(tap2, this.size);
+  };
+
+  _update(resolver, type) {
+    if (
+      type.typeName === 'fixed' &&
+      this.size === type.size &&
+      (!type.name || ~getAliases(this).indexOf(type.name))
+    ) {
+      resolver.size = this.size;
+      resolver._read = this._read;
+    }
+  };
+
+  _deref(schema) { schema.size = this.size; };
+
+  getSize() { return this.size; };
+
+  random() {
+    return RANDOM.nextBuffer(this.size);
+  };
 }
-util.inherits(FixedType, Type);
-
-FixedType.prototype._check = function (val, flags, hook) {
-  var b = Buffer.isBuffer(val) && val.length === this.size;
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
-
-FixedType.prototype._read = function (tap) {
-  return tap.readFixed(this.size);
-};
-
-FixedType.prototype._skip = function (tap) {
-  tap.skipFixed(this.size);
-};
-
-FixedType.prototype._write = function (tap, val) {
-  if (!Buffer.isBuffer(val) || val.length !== this.size) {
-    throwInvalidError(val, this);
-  }
-  tap.writeFixed(val, this.size);
-};
-
-FixedType.prototype._match = function (tap1, tap2) {
-  return tap1.matchFixed(tap2, this.size);
-};
 
 FixedType.prototype.compare = Buffer.compare;
-
-FixedType.prototype._update = function (resolver, type) {
-  if (
-    type.typeName === 'fixed' &&
-    this.size === type.size &&
-    (!type.name || ~getAliases(this).indexOf(type.name))
-  ) {
-    resolver.size = this.size;
-    resolver._read = this._read;
-  }
-};
-
 FixedType.prototype._copy = BytesType.prototype._copy;
-
-FixedType.prototype._deref = function (schema) { schema.size = this.size; };
-
-FixedType.prototype.getSize = function () { return this.size; };
-
 FixedType.prototype.typeName = 'fixed';
 
-FixedType.prototype.random = function () {
-  return RANDOM.nextBuffer(this.size);
-};
-
 /** Avro map. Represented as vanilla objects. */
-function MapType(schema, opts) {
-  Type.call(this);
-  if (!schema.values) {
-    throw new Error(f('missing map values: %j', schema));
+class MapType extends Type {
+  constructor(schema, opts) {
+    super()
+    if (!schema.values) {
+      throw new Error(`missing map values: ${JSON.stringify(schema)}`);
+    }
+    this.valuesType = Type.forSchema(schema.values, opts);
+    this._branchConstructor = this._createBranchConstructor();
+    Object.freeze(this);
   }
-  this.valuesType = Type.forSchema(schema.values, opts);
-  this._branchConstructor = this._createBranchConstructor();
-  Object.freeze(this);
-}
-util.inherits(MapType, Type);
 
-MapType.prototype._check = function (val, flags, hook, path) {
-  if (!val || typeof val != 'object' || Array.isArray(val)) {
+  _check(val, flags, hook, path) {
+    if (!val || typeof val != 'object' || Array.isArray(val)) {
+      if (hook) {
+        hook(val, this);
+      }
+      return false;
+    }
+
+    var keys = Object.keys(val);
+    var b = true;
+    var i, l, j, key;
     if (hook) {
-      hook(val, this);
-    }
-    return false;
-  }
-
-  var keys = Object.keys(val);
-  var b = true;
-  var i, l, j, key;
-  if (hook) {
-    // Slow path.
-    j = path.length;
-    path.push('');
-    for (i = 0, l = keys.length; i < l; i++) {
-      key = path[j] = keys[i];
-      if (!this.valuesType._check(val[key], flags, hook, path)) {
-        b = false;
+      // Slow path.
+      j = path.length;
+      path.push('');
+      for (i = 0, l = keys.length; i < l; i++) {
+        key = path[j] = keys[i];
+        if (!this.valuesType._check(val[key], flags, hook, path)) {
+          b = false;
+        }
       }
-    }
-    path.pop();
-  } else {
-    for (i = 0, l = keys.length; i < l; i++) {
-      if (!this.valuesType._check(val[keys[i]], flags)) {
-        return false;
-      }
-    }
-  }
-  return b;
-};
-
-MapType.prototype._read = function (tap) {
-  var values = this.valuesType;
-  var val = {};
-  var n;
-  while ((n = readArraySize(tap))) {
-    while (n--) {
-      var key = tap.readString();
-      val[key] = values._read(tap);
-    }
-  }
-  return val;
-};
-
-MapType.prototype._skip = function (tap) {
-  var values = this.valuesType;
-  var len, n;
-  while ((n = tap.readLong())) {
-    if (n < 0) {
-      len = tap.readLong();
-      tap.pos += len;
+      path.pop();
     } else {
-      while (n--) {
-        tap.skipString();
-        values._skip(tap);
+      for (i = 0, l = keys.length; i < l; i++) {
+        if (!this.valuesType._check(val[keys[i]], flags)) {
+          return false;
+        }
       }
     }
-  }
-};
+    return b;
+  };
 
-MapType.prototype._write = function (tap, val) {
-  if (!val || typeof val != 'object' || Array.isArray(val)) {
-    throwInvalidError(val, this);
-  }
-
-  var values = this.valuesType;
-  var keys = Object.keys(val);
-  var n = keys.length;
-  var i, key;
-  if (n) {
-    tap.writeLong(n);
-    for (i = 0; i < n; i++) {
-      key = keys[i];
-      tap.writeString(key);
-      values._write(tap, val[key]);
+  _read(tap) {
+    var values = this.valuesType;
+    var val = {};
+    var n;
+    while ((n = readArraySize(tap))) {
+      while (n--) {
+        var key = tap.readString();
+        val[key] = values._read(tap);
+      }
     }
-  }
-  tap.writeLong(0);
-};
+    return val;
+  };
 
-MapType.prototype._match = function () {
-  throw new Error('maps cannot be compared');
-};
+  _skip(tap) {
+    var values = this.valuesType;
+    var len, n;
+    while ((n = tap.readLong())) {
+      if (n < 0) {
+        len = tap.readLong();
+        tap.pos += len;
+      } else {
+        while (n--) {
+          tap.skipString();
+          values._skip(tap);
+        }
+      }
+    }
+  };
 
-MapType.prototype._update = function (rsv, type, opts) {
-  if (type.typeName === 'map') {
-    rsv.valuesType = this.valuesType.createResolver(type.valuesType, opts);
-    rsv._read = this._read;
-  }
-};
+  _write(tap, val) {
+    if (!val || typeof val != 'object' || Array.isArray(val)) {
+      throwInvalidError(val, this);
+    }
 
-MapType.prototype._copy = function (val, opts) {
-  if (val && typeof val == 'object' && !Array.isArray(val)) {
     var values = this.valuesType;
     var keys = Object.keys(val);
-    var i, l, key;
-    var copy = {};
-    for (i = 0, l = keys.length; i < l; i++) {
-      key = keys[i];
-      copy[key] = values._copy(val[key], opts);
+    var n = keys.length;
+    var i, key;
+    if (n) {
+      tap.writeLong(n);
+      for (i = 0; i < n; i++) {
+        key = keys[i];
+        tap.writeString(key);
+        values._write(tap, val[key]);
+      }
     }
-    return copy;
-  }
-  throwInvalidError(val, this);
-};
+    tap.writeLong(0);
+  };
+
+  _match() {
+    throw new Error('maps cannot be compared');
+  };
+
+  _update(rsv, type, opts) {
+    if (type.typeName === 'map') {
+      rsv.valuesType = this.valuesType.createResolver(type.valuesType, opts);
+      rsv._read = this._read;
+    }
+  };
+
+  _copy(val, opts) {
+    if (val && typeof val == 'object' && !Array.isArray(val)) {
+      var values = this.valuesType;
+      var keys = Object.keys(val);
+      var i, l, key;
+      var copy = {};
+      for (i = 0, l = keys.length; i < l; i++) {
+        key = keys[i];
+        copy[key] = values._copy(val[key], opts);
+      }
+      return copy;
+    }
+    throwInvalidError(val, this);
+  };
+
+  getValuesType() { return this.valuesType; };
+
+  random() {
+    var val = {};
+    var i, l;
+    for (i = 0, l = RANDOM.nextInt(10); i < l; i++) {
+      val[RANDOM.nextString(RANDOM.nextInt(20))] = this.valuesType.random();
+    }
+    return val;
+  };
+
+  _deref(schema, opts) {
+    schema.values = this.valuesType._attrs(opts);
+  };
+}
 
 MapType.prototype.compare = MapType.prototype._match;
-
 MapType.prototype.typeName = 'map';
 
-MapType.prototype.getValuesType = function () { return this.valuesType; };
-
-MapType.prototype.random = function () {
-  var val = {};
-  var i, l;
-  for (i = 0, l = RANDOM.nextInt(10); i < l; i++) {
-    val[RANDOM.nextString(RANDOM.nextInt(20))] = this.valuesType.random();
-  }
-  return val;
-};
-
-MapType.prototype._deref = function (schema, opts) {
-  schema.values = this.valuesType._attrs(opts);
-};
 
 /** Avro array. Represented as vanilla arrays. */
-function ArrayType(schema, opts) {
-  Type.call(this);
-  if (!schema.items) {
-    throw new Error(f('missing array items: %j', schema));
+class ArrayType extends Type {
+  constructor(schema, opts) {
+    super()
+    if (!schema.items) {
+      throw new Error(`missing array items: ${JSON.stringify(schema)}`);
+    }
+    this.itemsType = Type.forSchema(schema.items, opts);
+    this._branchConstructor = this._createBranchConstructor();
+    Object.freeze(this);
   }
-  this.itemsType = Type.forSchema(schema.items, opts);
-  this._branchConstructor = this._createBranchConstructor();
-  Object.freeze(this);
-}
-util.inherits(ArrayType, Type);
 
-ArrayType.prototype._check = function (val, flags, hook, path) {
-  if (!Array.isArray(val)) {
+  _check(val, flags, hook, path) {
+    if (!Array.isArray(val)) {
+      if (hook) {
+        hook(val, this);
+      }
+      return false;
+    }
+
+    var b = true;
+    var i, l, j;
     if (hook) {
-      hook(val, this);
-    }
-    return false;
-  }
-
-  var b = true;
-  var i, l, j;
-  if (hook) {
-    // Slow path.
-    j = path.length;
-    path.push('');
-    for (i = 0, l = val.length; i < l; i++) {
-      path[j] = '' + i;
-      if (!this.itemsType._check(val[i], flags, hook, path)) {
-        b = false;
+      // Slow path.
+      j = path.length;
+      path.push('');
+      for (i = 0, l = val.length; i < l; i++) {
+        path[j] = '' + i;
+        if (!this.itemsType._check(val[i], flags, hook, path)) {
+          b = false;
+        }
       }
-    }
-    path.pop();
-  } else {
-    for (i = 0, l = val.length; i < l; i++) {
-      if (!this.itemsType._check(val[i], flags)) {
-        return false;
-      }
-    }
-  }
-  return b;
-};
-
-ArrayType.prototype._read = function (tap) {
-  var items = this.itemsType;
-  var val = [];
-  var n;
-  while ((n = tap.readLong())) {
-    if (n < 0) {
-      n = -n;
-      tap.skipLong(); // Skip size.
-    }
-    while (n--) {
-      val.push(items._read(tap));
-    }
-  }
-  return val;
-};
-
-ArrayType.prototype._skip = function (tap) {
-  var len, n;
-  while ((n = tap.readLong())) {
-    if (n < 0) {
-      len = tap.readLong();
-      tap.pos += len;
+      path.pop();
     } else {
-      while (n--) {
-        this.itemsType._skip(tap);
+      for (i = 0, l = val.length; i < l; i++) {
+        if (!this.itemsType._check(val[i], flags)) {
+          return false;
+        }
       }
     }
-  }
-};
+    return b;
+  };
 
-ArrayType.prototype._write = function (tap, val) {
-  if (!Array.isArray(val)) {
-    throwInvalidError(val, this);
-  }
-
-  var n = val.length;
-  var i;
-  if (n) {
-    tap.writeLong(n);
-    for (i = 0; i < n; i++) {
-      this.itemsType._write(tap, val[i]);
+  _read(tap) {
+    var items = this.itemsType;
+    var val = [];
+    var n;
+    while ((n = tap.readLong())) {
+      if (n < 0) {
+        n = -n;
+        tap.skipLong(); // Skip size.
+      }
+      while (n--) {
+        val.push(items._read(tap));
+      }
     }
-  }
-  tap.writeLong(0);
-};
+    return val;
+  };
 
-ArrayType.prototype._match = function (tap1, tap2) {
-  var n1 = tap1.readLong();
-  var n2 = tap2.readLong();
-  var f;
-  while (n1 && n2) {
-    f = this.itemsType._match(tap1, tap2);
-    if (f) {
-      return f;
+  _skip(tap) {
+    var len, n;
+    while ((n = tap.readLong())) {
+      if (n < 0) {
+        len = tap.readLong();
+        tap.pos += len;
+      } else {
+        while (n--) {
+          this.itemsType._skip(tap);
+        }
+      }
     }
-    if (!--n1) {
-      n1 = readArraySize(tap1);
+  };
+
+  _write(tap, val) {
+    if (!Array.isArray(val)) {
+      throwInvalidError(val, this);
     }
-    if (!--n2) {
-      n2 = readArraySize(tap2);
+
+    var n = val.length;
+    var i;
+    if (n) {
+      tap.writeLong(n);
+      for (i = 0; i < n; i++) {
+        this.itemsType._write(tap, val[i]);
+      }
     }
-  }
-  return utils.compare(n1, n2);
-};
+    tap.writeLong(0);
+  };
 
-ArrayType.prototype._update = function (resolver, type, opts) {
-  if (type.typeName === 'array') {
-    resolver.itemsType = this.itemsType.createResolver(type.itemsType, opts);
-    resolver._read = this._read;
-  }
-};
-
-ArrayType.prototype._copy = function (val, opts) {
-  if (!Array.isArray(val)) {
-    throwInvalidError(val, this);
-  }
-  var items = new Array(val.length);
-  var i, l;
-  for (i = 0, l = val.length; i < l; i++) {
-    items[i] = this.itemsType._copy(val[i], opts);
-  }
-  return items;
-};
-
-ArrayType.prototype._deref = function (schema, opts) {
-  schema.items = this.itemsType._attrs(opts);
-};
-
-ArrayType.prototype.compare = function (val1, val2) {
-  var n1 = val1.length;
-  var n2 = val2.length;
-  var i, l, f;
-  for (i = 0, l = Math.min(n1, n2); i < l; i++) {
-    if ((f = this.itemsType.compare(val1[i], val2[i]))) {
-      return f;
+  _match(tap1, tap2) {
+    var n1 = tap1.readLong();
+    var n2 = tap2.readLong();
+    var f;
+    while (n1 && n2) {
+      f = this.itemsType._match(tap1, tap2);
+      if (f) {
+        return f;
+      }
+      if (!--n1) {
+        n1 = readArraySize(tap1);
+      }
+      if (!--n2) {
+        n2 = readArraySize(tap2);
+      }
     }
-  }
-  return utils.compare(n1, n2);
-};
+    return utils.compare(n1, n2);
+  };
 
-ArrayType.prototype.getItemsType = function () { return this.itemsType; };
+  _update(resolver, type, opts) {
+    if (type.typeName === 'array') {
+      resolver.itemsType = this.itemsType.createResolver(type.itemsType, opts);
+      resolver._read = this._read;
+    }
+  };
+
+  _copy(val, opts) {
+    if (!Array.isArray(val)) {
+      throwInvalidError(val, this);
+    }
+    var items = new Array(val.length);
+    var i, l;
+    for (i = 0, l = val.length; i < l; i++) {
+      items[i] = this.itemsType._copy(val[i], opts);
+    }
+    return items;
+  };
+
+  _deref(schema, opts) {
+    schema.items = this.itemsType._attrs(opts);
+  };
+
+  compare(val1, val2) {
+    var n1 = val1.length;
+    var n2 = val2.length;
+    var i, l, f;
+    for (i = 0, l = Math.min(n1, n2); i < l; i++) {
+      if ((f = this.itemsType.compare(val1[i], val2[i]))) {
+        return f;
+      }
+    }
+    return utils.compare(n1, n2);
+  };
+
+  getItemsType() { return this.itemsType; };
+
+  random() {
+    var arr = [];
+    var i, l;
+    for (i = 0, l = RANDOM.nextInt(10); i < l; i++) {
+      arr.push(this.itemsType.random());
+    }
+    return arr;
+  };
+}
+
 
 ArrayType.prototype.typeName = 'array';
 
-ArrayType.prototype.random = function () {
-  var arr = [];
-  var i, l;
-  for (i = 0, l = RANDOM.nextInt(10); i < l; i++) {
-    arr.push(this.itemsType.random());
-  }
-  return arr;
-};
 
 /**
  * Avro record.
@@ -2072,458 +2103,455 @@ ArrayType.prototype.random = function () {
  * This type is also used for errors (similar, except for the extra `Error`
  * constructor call) and for messages (see comment below).
  */
-function RecordType(schema, opts) {
-  // Force creation of the options object in case we need to register this
-  // record's name.
-  opts = opts || {};
+class RecordType extends Type {
+  constructor(schema, opts) {
+    // Force creation of the options object in case we need to register this
+    // record's name.
+    opts = opts || {};
 
-  // Save the namespace to restore it as we leave this record's scope.
-  var namespace = opts.namespace;
-  if (schema.namespace !== undefined) {
-    opts.namespace = schema.namespace;
-  } else if (schema.name) {
-    // Fully qualified names' namespaces are used when no explicit namespace
-    // attribute was specified.
-    var match = /^(.*)\.[^.]+$/.exec(schema.name);
-    if (match) {
-      opts.namespace = match[1];
-    }
-  }
-  Type.call(this, schema, opts);
-
-  if (!Array.isArray(schema.fields)) {
-    throw new Error(f('non-array record fields: %j', schema.fields));
-  }
-  if (utils.hasDuplicates(schema.fields, function (f) { return f.name; })) {
-    throw new Error(f('duplicate field name: %j', schema.fields));
-  }
-  this._fieldsByName = {};
-  this.fields = Object.freeze(schema.fields.map(function (f) {
-    var field = new Field(f, opts);
-    this._fieldsByName[field.name] = field;
-    return field;
-  }, this));
-  this._branchConstructor = this._createBranchConstructor();
-  this._isError = schema.type === 'error';
-  this.recordConstructor = this._createConstructor(opts.errorStackTraces);
-  this._read = this._createReader();
-  this._skip = this._createSkipper();
-  this._write = this._createWriter();
-  this._check = this._createChecker();
-
-  opts.namespace = namespace;
-  Object.freeze(this);
-}
-util.inherits(RecordType, Type);
-
-RecordType.prototype._getConstructorName = function () {
-  return this.name ?
-    unqualify(this.name) :
-    this._isError ? 'Error$' : 'Record$';
-};
-
-RecordType.prototype._createConstructor = function (errorStackTraces) {
-  // jshint -W054
-  var outerArgs = [];
-  var innerArgs = [];
-  var ds = []; // Defaults.
-  var innerBody = '';
-  var i, l, field, name, defaultValue, hasDefault, stackField;
-  for (i = 0, l = this.fields.length; i < l; i++) {
-    field = this.fields[i];
-    defaultValue = field.defaultValue;
-    hasDefault = defaultValue() !== undefined;
-    name = field.name;
-    if (
-      errorStackTraces && this._isError && name === 'stack' &&
-      Type.isType(field.type, 'string') && !hasDefault
-    ) {
-      // We keep track of whether we've encountered a valid stack field (in
-      // particular, without a default) to populate a stack trace below.
-      stackField = field;
-    }
-    innerArgs.push('v' + i);
-    innerBody += '  ';
-    if (!hasDefault) {
-      innerBody += 'this.' + name + ' = v' + i + ';\n';
-    } else {
-      innerBody += 'if (v' + i + ' === undefined) { ';
-      innerBody += 'this.' + name + ' = d' + ds.length + '(); ';
-      innerBody += '} else { this.' + name + ' = v' + i + '; }\n';
-      outerArgs.push('d' + ds.length);
-      ds.push(defaultValue);
-    }
-  }
-  if (stackField) {
-    // We should populate a stack trace.
-    innerBody += '  if (this.stack === undefined) { ';
-    /* istanbul ignore else */
-    if (typeof Error.captureStackTrace == 'function') {
-      // v8 runtimes, the easy case.
-      innerBody += 'Error.captureStackTrace(this, this.constructor);';
-    } else {
-      // A few other runtimes (e.g. SpiderMonkey), might not work everywhere.
-      innerBody += 'this.stack = Error().stack;';
-    }
-    innerBody += ' }\n';
-  }
-  var outerBody = 'return function ' + this._getConstructorName() + '(';
-  outerBody += innerArgs.join() + ') {\n' + innerBody + '};';
-  var Record = new Function(outerArgs.join(), outerBody).apply(undefined, ds);
-
-  var self = this;
-  Record.getType = function () { return self; };
-  Record.type = self;
-  if (this._isError) {
-    util.inherits(Record, Error);
-    Record.prototype.name = this._getConstructorName();
-  }
-  Record.prototype.clone = function (o) { return self.clone(this, o); };
-  Record.prototype.compare = function (v) { return self.compare(this, v); };
-  Record.prototype.isValid = function (o) { return self.isValid(this, o); };
-  Record.prototype.toBuffer = function () { return self.toBuffer(this); };
-  Record.prototype.toString = function () { return self.toString(this); };
-  Record.prototype.wrap = function () { return self.wrap(this); };
-  Record.prototype.wrapped = Record.prototype.wrap; // Deprecated.
-  return Record;
-};
-
-RecordType.prototype._createChecker = function () {
-  // jshint -W054
-  var names = [];
-  var values = [];
-  var name = this._getConstructorName();
-  var body = 'return function check' + name + '(v, f, h, p) {\n';
-  body += '  if (\n';
-  body += '    v === null ||\n';
-  body += '    typeof v != \'object\' ||\n';
-  body += '    (f && !this._checkFields(v))\n';
-  body += '  ) {\n';
-  body += '    if (h) { h(v, this); }\n';
-  body += '    return false;\n';
-  body += '  }\n';
-  if (!this.fields.length) {
-    // Special case, empty record. We handle this directly.
-    body += '  return true;\n';
-  } else {
-    for (i = 0, l = this.fields.length; i < l; i++) {
-      field = this.fields[i];
-      names.push('t' + i);
-      values.push(field.type);
-      if (field.defaultValue() !== undefined) {
-        body += '  var v' + i + ' = v.' + field.name + ';\n';
+    // Save the namespace to restore it as we leave this record's scope.
+    var namespace = opts.namespace;
+    if (schema.namespace !== undefined) {
+      opts.namespace = schema.namespace;
+    } else if (schema.name) {
+      // Fully qualified names' namespaces are used when no explicit namespace
+      // attribute was specified.
+      var match = /^(.*)\.[^.]+$/.exec(schema.name);
+      if (match) {
+        opts.namespace = match[1];
       }
     }
-    body += '  if (h) {\n';
-    body += '    var b = 1;\n';
-    body += '    var j = p.length;\n';
-    body += '    p.push(\'\');\n';
-    var i, l, field;
+    super(schema, opts);
+
+    if (!Array.isArray(schema.fields)) {
+      throw new Error(`non-array record fields: ${JSON.stringify(schema.fields)}`);
+    }
+    if (utils.hasDuplicates(schema.fields, function (f) { return f.name; })) {
+      throw new Error(`duplicate field name: ${JSON.stringify(schema.fields)}`);
+    }
+    this._fieldsByName = {};
+    this.fields = Object.freeze(schema.fields.map(function (f) {
+      var field = new Field(f, opts);
+      this._fieldsByName[field.name] = field;
+      return field;
+    }, this));
+    this._branchConstructor = this._createBranchConstructor();
+    this._isError = schema.type === 'error';
+    this.recordConstructor = this._createConstructor(opts.errorStackTraces);
+    this._read = this._createReader();
+    this._skip = this._createSkipper();
+    this._write = this._createWriter();
+    this._check = this._createChecker();
+
+    opts.namespace = namespace;
+    Object.freeze(this);
+  }
+
+  _getConstructorName() {
+    return this.name ?
+      unqualify(this.name) :
+      this._isError ? 'Error$' : 'Record$';
+  };
+
+  _createConstructor(errorStackTraces) {
+    // jshint -W054
+    var outerArgs = [];
+    var innerArgs = [];
+    var ds = []; // Defaults.
+    var innerBody = '';
+    var i, l, field, name, defaultValue, hasDefault, stackField;
     for (i = 0, l = this.fields.length; i < l; i++) {
       field = this.fields[i];
-      body += '    p[j] = \'' + field.name + '\';\n';
-      body += '    b &= ';
-      if (field.defaultValue() === undefined) {
-        body += 't' + i + '._check(v.' + field.name + ', f, h, p);\n';
+      defaultValue = field.defaultValue;
+      hasDefault = defaultValue() !== undefined;
+      name = field.name;
+      if (
+        errorStackTraces && this._isError && name === 'stack' &&
+        Type.isType(field.type, 'string') && !hasDefault
+      ) {
+        // We keep track of whether we've encountered a valid stack field (in
+        // particular, without a default) to populate a stack trace below.
+        stackField = field;
+      }
+      innerArgs.push('v' + i);
+      innerBody += '  ';
+      if (!hasDefault) {
+        innerBody += 'this.' + name + ' = v' + i + ';\n';
       } else {
-        body += 'v' + i + ' === undefined || ';
-        body += 't' + i + '._check(v' + i + ', f, h, p);\n';
+        innerBody += 'if (v' + i + ' === undefined) { ';
+        innerBody += 'this.' + name + ' = d' + ds.length + '(); ';
+        innerBody += '} else { this.' + name + ' = v' + i + '; }\n';
+        outerArgs.push('d' + ds.length);
+        ds.push(defaultValue);
       }
     }
-    body += '    p.pop();\n';
-    body += '    return !!b;\n';
-    body += '  } else {\n    return (\n      ';
-    body += this.fields.map(function (field, i) {
-      return field.defaultValue() === undefined ?
-        't' + i + '._check(v.' + field.name + ', f)' :
-        '(v' + i + ' === undefined || t' + i + '._check(v' + i + ', f))';
-    }).join(' &&\n      ');
-    body += '\n    );\n  }\n';
-  }
-  body += '};';
-  return new Function(names.join(), body).apply(undefined, values);
-};
+    if (stackField) {
+      // We should populate a stack trace.
+      innerBody += '  if (this.stack === undefined) { ';
+      /* istanbul ignore else */
+      if (typeof Error.captureStackTrace == 'function') {
+        // v8 runtimes, the easy case.
+        innerBody += 'Error.captureStackTrace(this, this.constructor);';
+      } else {
+        // A few other runtimes (e.g. SpiderMonkey), might not work everywhere.
+        innerBody += 'this.stack = Error().stack;';
+      }
+      innerBody += ' }\n';
+    }
+    var outerBody = 'return function ' + this._getConstructorName() + '(';
+    outerBody += innerArgs.join() + ') {\n' + innerBody + '};';
+    var Record = new Function(outerArgs.join(), outerBody).apply(undefined, ds);
 
-RecordType.prototype._createReader = function () {
-  // jshint -W054
-  var names = [];
-  var values = [this.recordConstructor];
-  var i, l;
-  for (i = 0, l = this.fields.length; i < l; i++) {
-    names.push('t' + i);
-    values.push(this.fields[i].type);
-  }
-  var name = this._getConstructorName();
-  var body = 'return function read' + name + '(t) {\n';
-  body += '  return new ' + name + '(\n    ';
-  body += names.map(function (s) { return s + '._read(t)'; }).join(',\n    ');
-  body += '\n  );\n};';
-  names.unshift(name);
-  // We can do this since the JS spec guarantees that function arguments are
-  // evaluated from left to right.
-  return new Function(names.join(), body).apply(undefined, values);
-};
+    var self = this;
+    Record.getType = function () { return self; };
+    Record.type = self;
+    if (this._isError) {
+      //util.inherits(Record, Error);
+      Record.prototype.name = this._getConstructorName();
+    }
+    Record.prototype.clone = function (o) { return self.clone(this, o); };
+    Record.prototype.compare = function (v) { return self.compare(this, v); };
+    Record.prototype.isValid = function (o) { return self.isValid(this, o); };
+    Record.prototype.toBuffer = function () { return self.toBuffer(this); };
+    Record.prototype.toString = function () { return self.toString(this); };
+    Record.prototype.wrap = function () { return self.wrap(this); };
+    Record.prototype.wrapped = Record.prototype.wrap; // Deprecated.
+    return Record;
+  };
 
-RecordType.prototype._createSkipper = function () {
-  // jshint -W054
-  var args = [];
-  var body = 'return function skip' + this._getConstructorName() + '(t) {\n';
-  var values = [];
-  var i, l;
-  for (i = 0, l = this.fields.length; i < l; i++) {
-    args.push('t' + i);
-    values.push(this.fields[i].type);
-    body += '  t' + i + '._skip(t);\n';
-  }
-  body += '}';
-  return new Function(args.join(), body).apply(undefined, values);
-};
-
-RecordType.prototype._createWriter = function () {
-  // jshint -W054
-  // We still do default handling here, in case a normal JS object is passed.
-  var args = [];
-  var name = this._getConstructorName();
-  var body = 'return function write' + name + '(t, v) {\n';
-  var values = [];
-  var i, l, field, value;
-  for (i = 0, l = this.fields.length; i < l; i++) {
-    field = this.fields[i];
-    args.push('t' + i);
-    values.push(field.type);
-    body += '  ';
-    if (field.defaultValue() === undefined) {
-      body += 't' + i + '._write(t, v.' + field.name + ');\n';
+  _createChecker() {
+    // jshint -W054
+    var names = [];
+    var values = [];
+    var name = this._getConstructorName();
+    var body = 'return function check' + name + '(v, f, h, p) {\n';
+    body += '  if (\n';
+    body += '    v === null ||\n';
+    body += '    typeof v != \'object\' ||\n';
+    body += '    (f && !this._checkFields(v))\n';
+    body += '  ) {\n';
+    body += '    if (h) { h(v, this); }\n';
+    body += '    return false;\n';
+    body += '  }\n';
+    if (!this.fields.length) {
+      // Special case, empty record. We handle this directly.
+      body += '  return true;\n';
     } else {
-      value = field.type.toBuffer(field.defaultValue()).toString('binary');
-      // Convert the default value to a binary string ahead of time. We aren't
-      // converting it to a buffer to avoid retaining too much memory. If we
-      // had our own buffer pool, this could be an idea in the future.
-      args.push('d' + i);
-      values.push(value);
-      body += 'var v' + i + ' = v.' + field.name + ';\n';
-      body += 'if (v' + i + ' === undefined) {\n';
-      body += '    t.writeBinary(d' + i + ', ' + value.length + ');\n';
-      body += '  } else {\n    t' + i + '._write(t, v' + i + ');\n  }\n';
+      for (i = 0, l = this.fields.length; i < l; i++) {
+        field = this.fields[i];
+        names.push('t' + i);
+        values.push(field.type);
+        if (field.defaultValue() !== undefined) {
+          body += '  var v' + i + ' = v.' + field.name + ';\n';
+        }
+      }
+      body += '  if (h) {\n';
+      body += '    var b = 1;\n';
+      body += '    var j = p.length;\n';
+      body += '    p.push(\'\');\n';
+      var i, l, field;
+      for (i = 0, l = this.fields.length; i < l; i++) {
+        field = this.fields[i];
+        body += '    p[j] = \'' + field.name + '\';\n';
+        body += '    b &= ';
+        if (field.defaultValue() === undefined) {
+          body += 't' + i + '._check(v.' + field.name + ', f, h, p);\n';
+        } else {
+          body += 'v' + i + ' === undefined || ';
+          body += 't' + i + '._check(v' + i + ', f, h, p);\n';
+        }
+      }
+      body += '    p.pop();\n';
+      body += '    return !!b;\n';
+      body += '  } else {\n    return (\n      ';
+      body += this.fields.map(function (field, i) {
+        return field.defaultValue() === undefined ?
+          't' + i + '._check(v.' + field.name + ', f)' :
+          '(v' + i + ' === undefined || t' + i + '._check(v' + i + ', f))';
+      }).join(' &&\n      ');
+      body += '\n    );\n  }\n';
     }
-  }
-  body += '}';
-  return new Function(args.join(), body).apply(undefined, values);
-};
+    body += '};';
+    return new Function(names.join(), body).apply(undefined, values);
+  };
 
-RecordType.prototype._update = function (resolver, type, opts) {
-  // jshint -W054
-  if (type.name && !~getAliases(this).indexOf(type.name)) {
-    throw new Error(f('no alias found for %s', type.name));
-  }
+  _createReader() {
+    // jshint -W054
+    var names = [];
+    var values = [this.recordConstructor];
+    var i, l;
+    for (i = 0, l = this.fields.length; i < l; i++) {
+      names.push('t' + i);
+      values.push(this.fields[i].type);
+    }
+    var name = this._getConstructorName();
+    var body = 'return function read' + name + '(t) {\n';
+    body += '  return new ' + name + '(\n    ';
+    body += names.map(function (s) { return s + '._read(t)'; }).join(',\n    ');
+    body += '\n  );\n};';
+    names.unshift(name);
+    // We can do this since the JS spec guarantees that function arguments are
+    // evaluated from left to right.
+    return new Function(names.join(), body).apply(undefined, values);
+  };
 
-  var rFields = this.fields;
-  var wFields = type.fields;
-  var wFieldsMap = utils.toMap(wFields, function (f) { return f.name; });
+  _createSkipper() {
+    // jshint -W054
+    var args = [];
+    var body = 'return function skip' + this._getConstructorName() + '(t) {\n';
+    var values = [];
+    var i, l;
+    for (i = 0, l = this.fields.length; i < l; i++) {
+      args.push('t' + i);
+      values.push(this.fields[i].type);
+      body += '  t' + i + '._skip(t);\n';
+    }
+    body += '}';
+    return new Function(args.join(), body).apply(undefined, values);
+  };
 
-  var innerArgs = []; // Arguments for reader constructor.
-  var resolvers = {}; // Resolvers keyed by writer field name.
-  var i, j, field, name, names, matches, fieldResolver;
-  for (i = 0; i < rFields.length; i++) {
-    field = rFields[i];
-    names = getAliases(field);
-    matches = [];
-    for (j = 0; j < names.length; j++) {
-      name = names[j];
-      if (wFieldsMap[name]) {
-        matches.push(name);
+  _createWriter() {
+    // jshint -W054
+    // We still do default handling here, in case a normal JS object is passed.
+    var args = [];
+    var name = this._getConstructorName();
+    var body = 'return function write' + name + '(t, v) {\n';
+    var values = [];
+    var i, l, field, value;
+    for (i = 0, l = this.fields.length; i < l; i++) {
+      field = this.fields[i];
+      args.push('t' + i);
+      values.push(field.type);
+      body += '  ';
+      if (field.defaultValue() === undefined) {
+        body += 't' + i + '._write(t, v.' + field.name + ');\n';
+      } else {
+        value = field.type.toBuffer(field.defaultValue()).toString('binary');
+        // Convert the default value to a binary string ahead of time. We aren't
+        // converting it to a buffer to avoid retaining too much memory. If we
+        // had our own buffer pool, this could be an idea in the future.
+        args.push('d' + i);
+        values.push(value);
+        body += 'var v' + i + ' = v.' + field.name + ';\n';
+        body += 'if (v' + i + ' === undefined) {\n';
+        body += '    t.writeBinary(d' + i + ', ' + value.length + ');\n';
+        body += '  } else {\n    t' + i + '._write(t, v' + i + ');\n  }\n';
       }
     }
-    if (matches.length > 1) {
-      throw new Error(
-        f('ambiguous aliasing for %s.%s (%s)', type.name, field.name, matches)
-      );
+    body += '}';
+    return new Function(args.join(), body).apply(undefined, values);
+  };
+
+  _update(resolver, type, opts) {
+    // jshint -W054
+    if (type.name && !~getAliases(this).indexOf(type.name)) {
+      throw new Error(`no alias found for ${type.name}`);
     }
-    if (!matches.length) {
-      if (field.defaultValue() === undefined) {
+
+    var rFields = this.fields;
+    var wFields = type.fields;
+    var wFieldsMap = utils.toMap(wFields, function (f) { return f.name; });
+
+    var innerArgs = []; // Arguments for reader constructor.
+    var resolvers = {}; // Resolvers keyed by writer field name.
+    var i, j, field, name, names, matches, fieldResolver;
+    for (i = 0; i < rFields.length; i++) {
+      field = rFields[i];
+      names = getAliases(field);
+      matches = [];
+      for (j = 0; j < names.length; j++) {
+        name = names[j];
+        if (wFieldsMap[name]) {
+          matches.push(name);
+        }
+      }
+      if (matches.length > 1) {
         throw new Error(
-          f('no matching field for default-less %s.%s', type.name, field.name)
+          `ambiguous aliasing for ${type.name}.${field.name} (${matches})`
         );
       }
-      innerArgs.push('undefined');
-    } else {
-      name = matches[0];
-      fieldResolver = {
-        resolver: field.type.createResolver(wFieldsMap[name].type, opts),
-        name: '_' + field.name, // Reader field name.
-      };
-      if (!resolvers[name]) {
-        resolvers[name] = [fieldResolver];
+      if (!matches.length) {
+        if (field.defaultValue() === undefined) {
+          throw new Error(
+            `no matching field for default-less ${type.name}.${field.name}`
+          );
+        }
+        innerArgs.push('undefined');
       } else {
-        resolvers[name].push(fieldResolver);
+        name = matches[0];
+        fieldResolver = {
+          resolver: field.type.createResolver(wFieldsMap[name].type, opts),
+          name: '_' + field.name, // Reader field name.
+        };
+        if (!resolvers[name]) {
+          resolvers[name] = [fieldResolver];
+        } else {
+          resolvers[name].push(fieldResolver);
+        }
+        innerArgs.push(fieldResolver.name);
       }
-      innerArgs.push(fieldResolver.name);
     }
-  }
 
-  // See if we can add a bypass for unused fields at the end of the record.
-  var lazyIndex = -1;
-  i = wFields.length;
-  while (i && resolvers[wFields[--i].name] === undefined) {
-    lazyIndex = i;
-  }
-
-  var uname = this._getConstructorName();
-  var args = [uname];
-  var values = [this.recordConstructor];
-  var body = '  return function read' + uname + '(t, b) {\n';
-  for (i = 0; i < wFields.length; i++) {
-    if (i === lazyIndex) {
-      body += '  if (!b) {\n';
+    // See if we can add a bypass for unused fields at the end of the record.
+    var lazyIndex = -1;
+    i = wFields.length;
+    while (i && resolvers[wFields[--i].name] === undefined) {
+      lazyIndex = i;
     }
-    field = type.fields[i];
-    name = field.name;
-    if (resolvers[name] === undefined) {
-      body += (~lazyIndex && i >= lazyIndex) ? '    ' : '  ';
-      args.push('r' + i);
-      values.push(field.type);
-      body += 'r' + i + '._skip(t);\n';
-    } else {
-      j = resolvers[name].length;
-      while (j--) {
+
+    var uname = this._getConstructorName();
+    var args = [uname];
+    var values = [this.recordConstructor];
+    var body = '  return function read' + uname + '(t, b) {\n';
+    for (i = 0; i < wFields.length; i++) {
+      if (i === lazyIndex) {
+        body += '  if (!b) {\n';
+      }
+      field = type.fields[i];
+      name = field.name;
+      if (resolvers[name] === undefined) {
         body += (~lazyIndex && i >= lazyIndex) ? '    ' : '  ';
-        args.push('r' + i + 'f' + j);
-        fieldResolver = resolvers[name][j];
-        values.push(fieldResolver.resolver);
-        body += 'var ' + fieldResolver.name + ' = ';
-        body += 'r' + i + 'f' + j + '._' + (j ? 'peek' : 'read') + '(t);\n';
+        args.push('r' + i);
+        values.push(field.type);
+        body += 'r' + i + '._skip(t);\n';
+      } else {
+        j = resolvers[name].length;
+        while (j--) {
+          body += (~lazyIndex && i >= lazyIndex) ? '    ' : '  ';
+          args.push('r' + i + 'f' + j);
+          fieldResolver = resolvers[name][j];
+          values.push(fieldResolver.resolver);
+          body += 'var ' + fieldResolver.name + ' = ';
+          body += 'r' + i + 'f' + j + '._' + (j ? 'peek' : 'read') + '(t);\n';
+        }
       }
     }
-  }
-  if (~lazyIndex) {
-    body += '  }\n';
-  }
-  body += '  return new ' + uname + '(' + innerArgs.join() + ');\n};';
+    if (~lazyIndex) {
+      body += '  }\n';
+    }
+    body += '  return new ' + uname + '(' + innerArgs.join() + ');\n};';
 
-  resolver._read = new Function(args.join(), body).apply(undefined, values);
-};
+    resolver._read = new Function(args.join(), body).apply(undefined, values);
+  };
 
-RecordType.prototype._match = function (tap1, tap2) {
-  var fields = this.fields;
-  var i, l, field, order, type;
-  for (i = 0, l = fields.length; i < l; i++) {
-    field = fields[i];
-    order = field._order;
-    type = field.type;
-    if (order) {
-      order *= type._match(tap1, tap2);
+  _match(tap1, tap2) {
+    var fields = this.fields;
+    var i, l, field, order, type;
+    for (i = 0, l = fields.length; i < l; i++) {
+      field = fields[i];
+      order = field._order;
+      type = field.type;
       if (order) {
-        return order;
+        order *= type._match(tap1, tap2);
+        if (order) {
+          return order;
+        }
+      } else {
+        type._skip(tap1);
+        type._skip(tap2);
       }
-    } else {
-      type._skip(tap1);
-      type._skip(tap2);
     }
-  }
-  return 0;
-};
+    return 0;
+  };
 
-RecordType.prototype._checkFields = function (obj) {
-  var keys = Object.keys(obj);
-  var i, l;
-  for (i = 0, l = keys.length; i < l; i++) {
-    if (!this._fieldsByName[keys[i]]) {
-      return false;
+  _checkFields(obj) {
+    var keys = Object.keys(obj);
+    var i, l;
+    for (i = 0, l = keys.length; i < l; i++) {
+      if (!this._fieldsByName[keys[i]]) {
+        return false;
+      }
     }
-  }
-  return true;
-};
+    return true;
+  };
 
-RecordType.prototype._copy = function (val, opts) {
-  // jshint -W058
-  var hook = opts && opts.fieldHook;
-  var values = [undefined];
-  var i, l, field, value;
-  for (i = 0, l = this.fields.length; i < l; i++) {
-    field = this.fields[i];
-    value = val[field.name];
-    if (value === undefined && field.hasOwnProperty('defaultValue')) {
-      value = field.defaultValue();
+  _copy(val, opts) {
+    // jshint -W058
+    var hook = opts && opts.fieldHook;
+    var values = [undefined];
+    var i, l, field, value;
+    for (i = 0, l = this.fields.length; i < l; i++) {
+      field = this.fields[i];
+      value = val[field.name];
+      if (value === undefined && field.hasOwnProperty('defaultValue')) {
+        value = field.defaultValue();
+      }
+      if ((opts && !opts.skip) || value !== undefined) {
+        value = field.type._copy(value, opts);
+      }
+      if (hook) {
+        value = hook(field, value, this);
+      }
+      values.push(value);
     }
-    if ((opts && !opts.skip) || value !== undefined) {
-      value = field.type._copy(value, opts);
-    }
-    if (hook) {
-      value = hook(field, value, this);
-    }
-    values.push(value);
-  }
-  var Record = this.recordConstructor;
-  return new (Record.bind.apply(Record, values))();
-};
+    var Record = this.recordConstructor;
+    return new (Record.bind.apply(Record, values))();
+  };
 
-RecordType.prototype._deref = function (schema, opts) {
-  schema.fields = this.fields.map(function (field) {
-    var fieldType = field.type;
-    var fieldSchema = {
-      name: field.name,
-      type: fieldType._attrs(opts)
-    };
-    if (opts.exportAttrs) {
-      var val = field.defaultValue();
-      if (val !== undefined) {
-        // We must both unwrap all unions and coerce buffers to strings.
-        fieldSchema['default'] = fieldType._copy(val, {coerce: 3, wrap: 3});
+  _deref(schema, opts) {
+    schema.fields = this.fields.map(function (field) {
+      var fieldType = field.type;
+      var fieldSchema = {
+        name: field.name,
+        type: fieldType._attrs(opts)
+      };
+      if (opts.exportAttrs) {
+        var val = field.defaultValue();
+        if (val !== undefined) {
+          // We must both unwrap all unions and coerce buffers to strings.
+          fieldSchema['default'] = fieldType._copy(val, { coerce: 3, wrap: 3 });
+        }
+        var fieldOrder = field.order;
+        if (fieldOrder !== 'ascending') {
+          fieldSchema.order = fieldOrder;
+        }
+        var fieldAliases = field.aliases;
+        if (fieldAliases.length) {
+          fieldSchema.aliases = fieldAliases;
+        }
+        var fieldDoc = field.doc;
+        if (fieldDoc !== undefined) {
+          fieldSchema.doc = fieldDoc;
+        }
       }
-      var fieldOrder = field.order;
-      if (fieldOrder !== 'ascending') {
-        fieldSchema.order = fieldOrder;
-      }
-      var fieldAliases = field.aliases;
-      if (fieldAliases.length) {
-        fieldSchema.aliases = fieldAliases;
-      }
-      var fieldDoc = field.doc;
-      if (fieldDoc !== undefined) {
-        fieldSchema.doc = fieldDoc;
-      }
-    }
-    return fieldSchema;
-  });
-};
+      return fieldSchema;
+    });
+  };
 
-RecordType.prototype.compare = function (val1, val2) {
-  var fields = this.fields;
-  var i, l, field, name, order, type;
-  for (i = 0, l = fields.length; i < l; i++) {
-    field = fields[i];
-    name = field.name;
-    order = field._order;
-    type = field.type;
-    if (order) {
-      order *= type.compare(val1[name], val2[name]);
+  compare(val1, val2) {
+    var fields = this.fields;
+    var i, l, field, name, order, type;
+    for (i = 0, l = fields.length; i < l; i++) {
+      field = fields[i];
+      name = field.name;
+      order = field._order;
+      type = field.type;
       if (order) {
-        return order;
+        order *= type.compare(val1[name], val2[name]);
+        if (order) {
+          return order;
+        }
       }
     }
-  }
-  return 0;
-};
+    return 0;
+  };
 
-RecordType.prototype.random = function () {
-  // jshint -W058
-  var fields = this.fields.map(function (f) { return f.type.random(); });
-  fields.unshift(undefined);
-  var Record = this.recordConstructor;
-  return new (Record.bind.apply(Record, fields))();
-};
+  random() {
+    // jshint -W058
+    var fields = this.fields.map(function (f) { return f.type.random(); });
+    fields.unshift(undefined);
+    var Record = this.recordConstructor;
+    return new (Record.bind.apply(Record, fields))();
+  };
 
-RecordType.prototype.field = function (name) {
-  return this._fieldsByName[name];
-};
+  field(name) {
+    return this._fieldsByName[name];
+  };
+}
+
 
 RecordType.prototype.getField = RecordType.prototype.field;
 
-RecordType.prototype.getFields = function () { return this.fields; };
-
-RecordType.prototype.getRecordConstructor = function () {
-  return this.recordConstructor;
-};
 
 Object.defineProperty(RecordType.prototype, 'typeName', {
   enumerable: true,
@@ -2531,33 +2559,112 @@ Object.defineProperty(RecordType.prototype, 'typeName', {
 });
 
 /** Derived type abstract class. */
-function LogicalType(schema, opts) {
-  this._logicalTypeName = schema.logicalType;
-  Type.call(this);
-  LOGICAL_TYPE = this;
-  try {
-    this._underlyingType = Type.forSchema(schema, opts);
-  } finally {
-    LOGICAL_TYPE = null;
-    // Remove the underlying type now that we're done instantiating. Note that
-    // in some (rare) cases, it might not have been inserted; for example, if
-    // this constructor was manually called with an already instantiated type.
-    var l = UNDERLYING_TYPES.length;
-    if (l && UNDERLYING_TYPES[l - 1][0] === this) {
-      UNDERLYING_TYPES.pop();
+class LogicalType extends Type {
+  constructor(schema, opts) {
+    this._logicalTypeName = schema.logicalType;
+    super()
+    LOGICAL_TYPE = this;
+    try {
+      this._underlyingType = Type.forSchema(schema, opts);
+    } finally {
+      LOGICAL_TYPE = null;
+      // Remove the underlying type now that we're done instantiating. Note that
+      // in some (rare) cases, it might not have been inserted; for example, if
+      // this constructor was manually called with an already instantiated type.
+      var l = UNDERLYING_TYPES.length;
+      if (l && UNDERLYING_TYPES[l - 1][0] === this) {
+        UNDERLYING_TYPES.pop();
+      }
     }
+    // We create a separate branch constructor for logical types to keep them
+    // monomorphic.
+    if (Type.isType(this.underlyingType, 'union')) {
+      this._branchConstructor = this.underlyingType._branchConstructor;
+    } else {
+      this._branchConstructor = this.underlyingType._createBranchConstructor();
+    }
+    // We don't freeze derived types to allow arbitrary properties. Implementors
+    // can still do so in the subclass' constructor at their convenience.
   }
-  // We create a separate branch constructor for logical types to keep them
-  // monomorphic.
-  if (Type.isType(this.underlyingType, 'union')) {
-    this._branchConstructor = this.underlyingType._branchConstructor;
-  } else {
-    this._branchConstructor = this.underlyingType._createBranchConstructor();
-  }
-  // We don't freeze derived types to allow arbitrary properties. Implementors
-  // can still do so in the subclass' constructor at their convenience.
+
+  getUnderlyingType() {
+    return this.underlyingType;
+  };
+
+  _read(tap) {
+    return this._fromValue(this.underlyingType._read(tap));
+  };
+
+  _write(tap, any) {
+    this.underlyingType._write(tap, this._toValue(any));
+  };
+
+  _check(any, flags, hook, path) {
+    try {
+      var val = this._toValue(any);
+    } catch (err) {
+      // Handled below.
+    }
+    if (val === undefined) {
+      if (hook) {
+        hook(any, this);
+      }
+      return false;
+    }
+    return this.underlyingType._check(val, flags, hook, path);
+  };
+
+  _copy(any, opts) {
+    var type = this.underlyingType;
+    switch (opts && opts.coerce) {
+      case 3: // To string.
+        return type._copy(this._toValue(any), opts);
+      case 2: // From string.
+        return this._fromValue(type._copy(any, opts));
+      default: // Normal copy.
+        return this._fromValue(type._copy(this._toValue(any), opts));
+    }
+  };
+
+  _update(resolver, type, opts) {
+    var _fromValue = this._resolve(type, opts);
+    if (_fromValue) {
+      resolver._read = function (tap) { return _fromValue(type._read(tap)); };
+    }
+  };
+
+  compare(obj1, obj2) {
+    var val1 = this._toValue(obj1);
+    var val2 = this._toValue(obj2);
+    return this.underlyingType.compare(val1, val2);
+  };
+
+  random() {
+    return this._fromValue(this.underlyingType.random());
+  };
+
+  _deref(schema, opts) {
+    var type = this.underlyingType;
+    var isVisited = type.name !== undefined && opts.derefed[type.name];
+    schema = type._attrs(opts);
+    if (!isVisited && opts.exportAttrs) {
+      if (typeof schema == 'string') {
+        schema = { type: schema };
+      }
+      schema.logicalType = this._logicalTypeName;
+      this._export(schema);
+    }
+    return schema;
+  };
+
+  _skip(tap) {
+    this.underlyingType._skip(tap);
+  };
+
+  // Unlike the other methods below, `_export` has a reasonable default which we
+  // can provide (not exporting anything).
+  _export(/* schema */) { };
 }
-util.inherits(LogicalType, Type);
 
 Object.defineProperty(LogicalType.prototype, 'typeName', {
   enumerable: true,
@@ -2583,83 +2690,6 @@ Object.defineProperty(LogicalType.prototype, 'underlyingType', {
   }
 });
 
-LogicalType.prototype.getUnderlyingType = function () {
-  return this.underlyingType;
-};
-
-LogicalType.prototype._read = function (tap) {
-  return this._fromValue(this.underlyingType._read(tap));
-};
-
-LogicalType.prototype._write = function (tap, any) {
-  this.underlyingType._write(tap, this._toValue(any));
-};
-
-LogicalType.prototype._check = function (any, flags, hook, path) {
-  try {
-    var val = this._toValue(any);
-  } catch (err) {
-    // Handled below.
-  }
-  if (val === undefined) {
-    if (hook) {
-      hook(any, this);
-    }
-    return false;
-  }
-  return this.underlyingType._check(val, flags, hook, path);
-};
-
-LogicalType.prototype._copy = function (any, opts) {
-  var type = this.underlyingType;
-  switch (opts && opts.coerce) {
-    case 3: // To string.
-      return type._copy(this._toValue(any), opts);
-    case 2: // From string.
-      return this._fromValue(type._copy(any, opts));
-    default: // Normal copy.
-      return this._fromValue(type._copy(this._toValue(any), opts));
-  }
-};
-
-LogicalType.prototype._update = function (resolver, type, opts) {
-  var _fromValue = this._resolve(type, opts);
-  if (_fromValue) {
-    resolver._read = function (tap) { return _fromValue(type._read(tap)); };
-  }
-};
-
-LogicalType.prototype.compare = function (obj1, obj2) {
-  var val1 = this._toValue(obj1);
-  var val2 = this._toValue(obj2);
-  return this.underlyingType.compare(val1, val2);
-};
-
-LogicalType.prototype.random = function () {
-  return this._fromValue(this.underlyingType.random());
-};
-
-LogicalType.prototype._deref = function (schema, opts) {
-  var type = this.underlyingType;
-  var isVisited = type.name !== undefined && opts.derefed[type.name];
-  schema = type._attrs(opts);
-  if (!isVisited && opts.exportAttrs) {
-    if (typeof schema == 'string') {
-      schema = {type: schema};
-    }
-    schema.logicalType = this._logicalTypeName;
-    this._export(schema);
-  }
-  return schema;
-};
-
-LogicalType.prototype._skip = function (tap) {
-  this.underlyingType._skip(tap);
-};
-
-// Unlike the other methods below, `_export` has a reasonable default which we
-// can provide (not exporting anything).
-LogicalType.prototype._export = function (/* schema */) {};
 
 // Methods to be implemented.
 LogicalType.prototype._fromValue = utils.abstractFunction;
@@ -2677,83 +2707,86 @@ LogicalType.prototype._resolve = utils.abstractFunction;
  * can't use a logical type because we need a "lower-level" hook here: passing
  * through through the standard long would cause a loss of precision.
  */
-function AbstractLongType(noUnpack) {
-  this._concreteTypeName = 'long';
-  PrimitiveType.call(this, true);
-  // Note that this type "inherits" `LongType` (i.e. gain its prototype
-  // methods) but only "subclasses" `PrimitiveType` to avoid being prematurely
-  // frozen.
-  this._noUnpack = !!noUnpack;
+class AbstractLongType extends LongType {
+  constructor(noUnpack) {
+    this._concreteTypeName = 'long';
+    super() // @FIXME: this probably  broke something
+    PrimitiveType.call(this, true);
+    // Note that this type "inherits" `LongType` (i.e. gain its prototype
+    // methods) but only "subclasses" `PrimitiveType` to avoid being prematurely
+    // frozen.
+    this._noUnpack = !!noUnpack;
+  }
+
+  _check(val, flags, hook) {
+    var b = this._isValid(val);
+    if (!b && hook) {
+      hook(val, this);
+    }
+    return b;
+  };
+
+  _read(tap) {
+    var buf, pos;
+    if (this._noUnpack) {
+      pos = tap.pos;
+      tap.skipLong();
+      buf = tap.buf.slice(pos, tap.pos);
+    } else {
+      buf = tap.unpackLongBytes(tap);
+    }
+    if (tap.isValid()) {
+      return this._fromBuffer(buf);
+    }
+  };
+
+  _write(tap, val) {
+    if (!this._isValid(val)) {
+      throwInvalidError(val, this);
+    }
+    var buf = this._toBuffer(val);
+    if (this._noUnpack) {
+      tap.writeFixed(buf);
+    } else {
+      tap.packLongBytes(buf);
+    }
+  };
+
+  _copy(val, opts) {
+    switch (opts && opts.coerce) {
+      case 3: // To string.
+        return this._toJSON(val);
+      case 2: // From string.
+        return this._fromJSON(val);
+      default: // Normal copy.
+        // Slow but guarantees most consistent results. Faster alternatives would
+        // require assumptions on the long class used (e.g. immutability).
+        return this._fromJSON(this._toJSON(val));
+    }
+  };
+
+  _deref() { return 'long'; }
+
+  _update(resolver, type) {
+    var self = this;
+    switch (type.typeName) {
+      case 'int':
+        resolver._read = function (tap) {
+          return self._fromJSON(type._read(tap));
+        };
+        break;
+      case 'long':
+        resolver._read = function (tap) { return self._read(tap); };
+    }
+  };
+
+  random() {
+    return this._fromJSON(LongType.prototype.random());
+  };
 }
-util.inherits(AbstractLongType, LongType);
 
 AbstractLongType.prototype.typeName = 'abstract:long';
 
-AbstractLongType.prototype._check = function (val, flags, hook) {
-  var b = this._isValid(val);
-  if (!b && hook) {
-    hook(val, this);
-  }
-  return b;
-};
-
-AbstractLongType.prototype._read = function (tap) {
-  var buf, pos;
-  if (this._noUnpack) {
-    pos = tap.pos;
-    tap.skipLong();
-    buf = tap.buf.slice(pos, tap.pos);
-  } else {
-    buf = tap.unpackLongBytes(tap);
-  }
-  if (tap.isValid()) {
-    return this._fromBuffer(buf);
-  }
-};
-
-AbstractLongType.prototype._write = function (tap, val) {
-  if (!this._isValid(val)) {
-    throwInvalidError(val, this);
-  }
-  var buf = this._toBuffer(val);
-  if (this._noUnpack) {
-    tap.writeFixed(buf);
-  } else {
-    tap.packLongBytes(buf);
-  }
-};
-
-AbstractLongType.prototype._copy = function (val, opts) {
-  switch (opts && opts.coerce) {
-    case 3: // To string.
-      return this._toJSON(val);
-    case 2: // From string.
-      return this._fromJSON(val);
-    default: // Normal copy.
-      // Slow but guarantees most consistent results. Faster alternatives would
-      // require assumptions on the long class used (e.g. immutability).
-      return this._fromJSON(this._toJSON(val));
-  }
-};
-
-AbstractLongType.prototype._deref = function () { return 'long'; }
-
-AbstractLongType.prototype._update = function (resolver, type) {
-  var self = this;
-  switch (type.typeName) {
-    case 'int':
-      resolver._read = function (tap) {
-        return self._fromJSON(type._read(tap));
-      };
-      break;
-    case 'long':
-      resolver._read = function (tap) { return self._read(tap); };
-  }
-};
-
-AbstractLongType.prototype.random = function () {
-  return this._fromJSON(LongType.prototype.random());
-};
 
 // Methods to be implemented by the user.
 AbstractLongType.prototype._fromBuffer = utils.abstractFunction;
@@ -2764,51 +2797,61 @@ AbstractLongType.prototype._isValid = utils.abstractFunction;
 AbstractLongType.prototype.compare = utils.abstractFunction;
 
 /** A record field. */
-function Field(schema, opts) {
-  var name = schema.name;
-  if (typeof name != 'string' || !isValidName(name)) {
-    throw new Error(f('invalid field name: %s', name));
+class Field {
+  constructor(schema, opts) {
+    var name = schema.name;
+    if (typeof name != 'string' || !isValidName(name)) {
+      throw new Error(`invalid field name: ${name}`);
+    }
+
+    this.name = name;
+    this.type = Type.forSchema(schema.type, opts);
+    this.aliases = schema.aliases || [];
+    this.doc = schema.doc !== undefined ? '' + schema.doc : undefined;
+
+    this._order = (function (order) {
+      switch (order) {
+        case 'ascending':
+          return 1;
+        case 'descending':
+          return -1;
+        case 'ignore':
+          return 0;
+        default:
+          throw new Error(`invalid order: ${JSON.stringify(order)}`);
+      }
+    })(schema.order === undefined ? 'ascending' : schema.order);
+
+    var value = schema['default'];
+    if (value !== undefined) {
+      // We need to convert defaults back to a valid format (unions are
+      // disallowed in default definitions, only the first type of each union is
+      // allowed instead).
+      // http://apache-avro.679487.n3.nabble.com/field-union-default-in-Java-td1175327.html
+      var type = this.type;
+      var val = type._copy(value, { coerce: 2, wrap: 2 });
+      // The clone call above will throw an error if the default is invalid.
+      if (isPrimitive(type.typeName) && type.typeName !== 'bytes') {
+        // These are immutable.
+        this.defaultValue = function () { return val; };
+      } else {
+        this.defaultValue = function () { return type._copy(val); };
+      }
+    }
+
+    Object.freeze(this);
   }
 
-  this.name = name;
-  this.type = Type.forSchema(schema.type, opts);
-  this.aliases = schema.aliases || [];
-  this.doc = schema.doc !== undefined ? '' + schema.doc : undefined;
+  defaultValue() { }; // Undefined default.
+  getAliases() { return this.aliases; };
 
-  this._order = (function (order) {
-    switch (order) {
-      case 'ascending':
-        return 1;
-      case 'descending':
-        return -1;
-      case 'ignore':
-        return 0;
-      default:
-        throw new Error(f('invalid order: %j', order));
-    }
-  })(schema.order === undefined ? 'ascending' : schema.order);
+  getName() { return this.name; };
 
-  var value = schema['default'];
-  if (value !== undefined) {
-    // We need to convert defaults back to a valid format (unions are
-    // disallowed in default definitions, only the first type of each union is
-    // allowed instead).
-    // http://apache-avro.679487.n3.nabble.com/field-union-default-in-Java-td1175327.html
-    var type = this.type;
-    var val = type._copy(value, {coerce: 2, wrap: 2});
-    // The clone call above will throw an error if the default is invalid.
-    if (isPrimitive(type.typeName) && type.typeName !== 'bytes') {
-      // These are immutable.
-      this.defaultValue = function () { return val; };
-    } else {
-      this.defaultValue = function () { return type._copy(val); };
-    }
-  }
+  getOrder() { return this.order; };
 
-  Object.freeze(this);
+  getType() { return this.type; };
 }
 
-Field.prototype.defaultValue = function () {}; // Undefined default.
 
 Object.defineProperty(Field.prototype, 'order', {
   enumerable: true,
@@ -2817,38 +2860,37 @@ Object.defineProperty(Field.prototype, 'order', {
   }
 });
 
-Field.prototype.getAliases = function () { return this.aliases; };
 
 Field.prototype.getDefault = Field.prototype.defaultValue;
 
-Field.prototype.getName = function () { return this.name; };
-
-Field.prototype.getOrder = function () { return this.order; };
-
-Field.prototype.getType = function () { return this.type; };
 
 /**
  * Resolver to read a writer's schema as a new schema.
  *
  * @param readerType {Type} The type to convert to.
  */
-function Resolver(readerType) {
-  // Add all fields here so that all resolvers share the same hidden class.
-  this._readerType = readerType;
-  this._read = null;
-  this.itemsType = null;
-  this.size = 0;
-  this.symbols = null;
-  this.valuesType = null;
+class Resolver {
+  constructor(readerType) {
+    // Add all fields here so that all resolvers share the same hidden class.
+    this._readerType = readerType;
+    this._read = null;
+    this.itemsType = null;
+    this.size = 0;
+    this.symbols = null;
+    this.valuesType = null;
+  }
+
+  inspect() { return '<Resolver>'; };
 }
 
 Resolver.prototype._peek = Type.prototype._peek;
 
-Resolver.prototype.inspect = function () { return '<Resolver>'; };
 
 /** Mutable hash container. */
-function Hash() {
-  this.str = undefined;
+class Hash {
+    constructor() {
+        this.str = undefined;
+    }
 }
 
 /**
@@ -2895,7 +2937,7 @@ function qualify(name, namespace) {
   }
   name.split('.').forEach(function (part) {
     if (!isValidName(part)) {
-      throw new Error(f('invalid name: %j', name));
+      throw new Error(`invalid name: ${JSON.stringify(name)}`);
     }
   });
   var tail = unqualify(name);
@@ -3012,7 +3054,7 @@ function isValidName(str) { return NAME_PATTERN.test(str); }
  * with a hook since the path is not propagated (for efficiency reasons).
  */
 function throwInvalidError(val, type) {
-  throw new Error(f('invalid %s: %j', type, val));
+  throw new Error(`invalid ${type}: ${JSON.stringify(val)}`);
 }
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -24,24 +24,6 @@ var utils = require('./utils'),
 var Tap = utils.Tap;
 //var debug = util.debuglog('avsc:types');
 
-// All non-union concrete (i.e. non-logical) Avro types.
-var TYPES = {
-  'array': ArrayType,
-  'boolean': BooleanType,
-  'bytes': BytesType,
-  'double': DoubleType,
-  'enum': EnumType,
-  'error': RecordType,
-  'fixed': FixedType,
-  'float': FloatType,
-  'int': IntType,
-  'long': LongType,
-  'map': MapType,
-  'null': NullType,
-  'record': RecordType,
-  'string': StringType
-};
-
 // Valid (field, type, and symbol) name regex.
 var NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -3304,6 +3286,23 @@ function combineObjects(types, opts) {
   return Type.forSchema(schema, opts);
 }
 
+// All non-union concrete (i.e. non-logical) Avro types.
+var TYPES = {
+  'array': ArrayType,
+  'boolean': BooleanType,
+  'bytes': BytesType,
+  'double': DoubleType,
+  'enum': EnumType,
+  'error': RecordType,
+  'fixed': FixedType,
+  'float': FloatType,
+  'int': IntType,
+  'long': LongType,
+  'map': MapType,
+  'null': NullType,
+  'record': RecordType,
+  'string': StringType
+};
 
 module.exports = {
   Type: Type,

--- a/lib/types.js
+++ b/lib/types.js
@@ -2206,7 +2206,7 @@ class RecordType extends Type {
     Record.getType = function () { return self; };
     Record.type = self;
     if (this._isError) {
-      //util.inherits(Record, Error);
+      //util.inherits(Record, Error); //@FIXME: This probably broke something
       Record.prototype.name = this._getConstructorName();
     }
     Record.prototype.clone = function (o) { return self.clone(this, o); };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,8 +7,8 @@
 
 /** Various utilities used across this library. */
 
+//var md5 = require('md5.js');
 var crypto = require('crypto');
-var util = require('util');
 
 // Shared buffer pool for all taps.
 var POOL = new BufferPool(4096);
@@ -76,7 +76,8 @@ function getOption(opts, key, def) {
  * @param str {String} The string to hash.
  * @param algorithm {String} The algorithm used. Defaults to MD5.
  */
-function getHash(str, algorithm) {
+function getHash(str) {
+  //var hash = new md5();
   algorithm = algorithm || 'md5';
   var hash = crypto.createHash(algorithm);
   hash.end(str);
@@ -242,10 +243,7 @@ function addDeprecatedGetters(obj, props) {
   for (i = 0, l = props.length; i < l; i++) {
     prop = props[i];
     getter = 'get' + capitalize(prop);
-    proto[getter] = util.deprecate(
-      createGetter(prop),
-      'use `.' + prop + '` instead of `.' + getter + '()`'
-    );
+    proto[getter] = createGetter(prop)
   }
 
   function createGetter(prop) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,59 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://npm.screenmeet.com/@babel%2fcode-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://npm.screenmeet.com/@babel%2fhighlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://npm.screenmeet.com/@types%2festree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "@types/node": {
+      "version": "11.9.5",
+      "resolved": "https://npm.screenmeet.com/@types%2fnode/-/node-11.9.5.tgz",
+      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q=="
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
+    },
+    "abstract-leveldown": {
+      "version": "0.12.4",
+      "resolved": "https://npm.screenmeet.com/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+      "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+      "requires": {
+        "xtend": "~3.0.0"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://npm.screenmeet.com/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
+    },
+    "acorn": {
+      "version": "6.1.0",
+      "resolved": "https://npm.screenmeet.com/acorn/-/acorn-6.1.0.tgz",
+      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -29,6 +77,14 @@
       "dev": true,
       "optional": true
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://npm.screenmeet.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -38,17 +94,52 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://npm.screenmeet.com/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://npm.screenmeet.com/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://npm.screenmeet.com/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://npm.screenmeet.com/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
+    "asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://npm.screenmeet.com/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
       "version": "1.5.2",
@@ -61,6 +152,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://npm.screenmeet.com/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -79,6 +175,61 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://npm.screenmeet.com/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://npm.screenmeet.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://npm.screenmeet.com/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -100,6 +251,42 @@
         "platform": "^1.3.3"
       }
     },
+    "bl": {
+      "version": "0.8.2",
+      "resolved": "https://npm.screenmeet.com/bl/-/bl-0.8.2.tgz",
+      "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+      "requires": {
+        "readable-stream": "~1.0.26"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://npm.screenmeet.com/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://npm.screenmeet.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://npm.screenmeet.com/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://npm.screenmeet.com/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -119,11 +306,155 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://npm.screenmeet.com/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://npm.screenmeet.com/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://npm.screenmeet.com/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://npm.screenmeet.com/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-fs": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/browserify-fs/-/browserify-fs-1.0.0.tgz",
+      "integrity": "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8=",
+      "requires": {
+        "level-filesystem": "^1.0.1",
+        "level-js": "^2.1.3",
+        "levelup": "^0.18.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://npm.screenmeet.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://npm.screenmeet.com/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "requires": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      }
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://npm.screenmeet.com/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-es6": {
+      "version": "4.9.3",
+      "resolved": "https://npm.screenmeet.com/buffer-es6/-/buffer-es6-4.9.3.tgz",
+      "integrity": "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://npm.screenmeet.com/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://npm.screenmeet.com/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "builtin-modules": {
+      "version": "3.0.0",
+      "resolved": "https://npm.screenmeet.com/builtin-modules/-/builtin-modules-3.0.0.tgz",
+      "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg=="
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -131,11 +462,93 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://npm.screenmeet.com/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://npm.screenmeet.com/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://npm.screenmeet.com/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://npm.screenmeet.com/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://npm.screenmeet.com/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "clone": {
+      "version": "0.1.19",
+      "resolved": "https://npm.screenmeet.com/clone/-/clone-0.1.19.tgz",
+      "integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://npm.screenmeet.com/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://npm.screenmeet.com/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -152,17 +565,37 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://npm.screenmeet.com/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://npm.screenmeet.com/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://npm.screenmeet.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
       "version": "3.0.1",
@@ -175,6 +608,40 @@
         "log-driver": "^1.2.5",
         "minimist": "^1.2.0",
         "request": "^2.79.0"
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.3",
+      "resolved": "https://npm.screenmeet.com/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://npm.screenmeet.com/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://npm.screenmeet.com/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cryptiles": {
@@ -197,6 +664,24 @@
         }
       }
     },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://npm.screenmeet.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -215,11 +700,61 @@
         "ms": "2.0.0"
       }
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://npm.screenmeet.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deferred-leveldown": {
+      "version": "0.2.0",
+      "resolved": "https://npm.screenmeet.com/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+      "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+      "requires": {
+        "abstract-leveldown": "~0.12.1"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://npm.screenmeet.com/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://npm.screenmeet.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -227,11 +762,30 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://npm.screenmeet.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -243,11 +797,32 @@
         "jsbn": "~0.1.0"
       }
     },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://npm.screenmeet.com/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://npm.screenmeet.com/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
@@ -282,17 +857,148 @@
       "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.5.2",
+      "resolved": "https://npm.screenmeet.com/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://npm.screenmeet.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://npm.screenmeet.com/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://npm.screenmeet.com/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://npm.screenmeet.com/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://npm.screenmeet.com/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://npm.screenmeet.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -318,6 +1024,37 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://npm.screenmeet.com/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://npm.screenmeet.com/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://npm.screenmeet.com/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -335,11 +1072,55 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://npm.screenmeet.com/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fwd-stream": {
+      "version": "1.0.4",
+      "resolved": "https://npm.screenmeet.com/fwd-stream/-/fwd-stream-1.0.4.tgz",
+      "integrity": "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=",
+      "requires": {
+        "readable-stream": "~1.0.26-4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://npm.screenmeet.com/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://npm.screenmeet.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://npm.screenmeet.com/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://npm.screenmeet.com/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
@@ -420,6 +1201,53 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://npm.screenmeet.com/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://npm.screenmeet.com/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -438,6 +1266,16 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
@@ -455,6 +1293,21 @@
         "sshpk": "^1.7.0"
       }
     },
+    "idb-wrapper": {
+      "version": "1.7.2",
+      "resolved": "https://npm.screenmeet.com/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
+      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
+    },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://npm.screenmeet.com/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://npm.screenmeet.com/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -468,8 +1321,111 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is": {
+      "version": "0.2.7",
+      "resolved": "https://npm.screenmeet.com/is/-/is-0.2.7.tgz",
+      "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://npm.screenmeet.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://npm.screenmeet.com/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://npm.screenmeet.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://npm.screenmeet.com/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://npm.screenmeet.com/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://npm.screenmeet.com/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-object": {
+      "version": "0.1.2",
+      "resolved": "https://npm.screenmeet.com/is-object/-/is-object-0.1.2.tgz",
+      "integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://npm.screenmeet.com/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -477,11 +1433,31 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://npm.screenmeet.com/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isbuffer": {
+      "version": "0.0.0",
+      "resolved": "https://npm.screenmeet.com/isbuffer/-/isbuffer-0.0.0.tgz",
+      "integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://npm.screenmeet.com/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -518,6 +1494,35 @@
           "dev": true
         }
       }
+    },
+    "jest-worker": {
+      "version": "24.0.0",
+      "resolved": "https://npm.screenmeet.com/jest-worker/-/jest-worker-24.0.0.tgz",
+      "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
+      "requires": {
+        "merge-stream": "^1.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://npm.screenmeet.com/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://npm.screenmeet.com/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://npm.screenmeet.com/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -566,11 +1571,191 @@
         "verror": "1.10.0"
       }
     },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
     "lcov-parse": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
+    },
+    "level-blobs": {
+      "version": "0.1.7",
+      "resolved": "https://npm.screenmeet.com/level-blobs/-/level-blobs-0.1.7.tgz",
+      "integrity": "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8=",
+      "requires": {
+        "level-peek": "1.0.6",
+        "once": "^1.3.0",
+        "readable-stream": "^1.0.26-4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://npm.screenmeet.com/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://npm.screenmeet.com/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://npm.screenmeet.com/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "level-filesystem": {
+      "version": "1.2.0",
+      "resolved": "https://npm.screenmeet.com/level-filesystem/-/level-filesystem-1.2.0.tgz",
+      "integrity": "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=",
+      "requires": {
+        "concat-stream": "^1.4.4",
+        "errno": "^0.1.1",
+        "fwd-stream": "^1.0.4",
+        "level-blobs": "^0.1.7",
+        "level-peek": "^1.0.6",
+        "level-sublevel": "^5.2.0",
+        "octal": "^1.0.0",
+        "once": "^1.3.0",
+        "xtend": "^2.2.0"
+      }
+    },
+    "level-fix-range": {
+      "version": "1.0.2",
+      "resolved": "https://npm.screenmeet.com/level-fix-range/-/level-fix-range-1.0.2.tgz",
+      "integrity": "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg="
+    },
+    "level-hooks": {
+      "version": "4.5.0",
+      "resolved": "https://npm.screenmeet.com/level-hooks/-/level-hooks-4.5.0.tgz",
+      "integrity": "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=",
+      "requires": {
+        "string-range": "~1.2"
+      }
+    },
+    "level-js": {
+      "version": "2.2.4",
+      "resolved": "https://npm.screenmeet.com/level-js/-/level-js-2.2.4.tgz",
+      "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
+      "requires": {
+        "abstract-leveldown": "~0.12.0",
+        "idb-wrapper": "^1.5.0",
+        "isbuffer": "~0.0.0",
+        "ltgt": "^2.1.2",
+        "typedarray-to-buffer": "~1.0.0",
+        "xtend": "~2.1.2"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://npm.screenmeet.com/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://npm.screenmeet.com/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
+    "level-peek": {
+      "version": "1.0.6",
+      "resolved": "https://npm.screenmeet.com/level-peek/-/level-peek-1.0.6.tgz",
+      "integrity": "sha1-vsUccqgu5GTTNkNMfIdsP8vM538=",
+      "requires": {
+        "level-fix-range": "~1.0.2"
+      }
+    },
+    "level-sublevel": {
+      "version": "5.2.3",
+      "resolved": "https://npm.screenmeet.com/level-sublevel/-/level-sublevel-5.2.3.tgz",
+      "integrity": "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=",
+      "requires": {
+        "level-fix-range": "2.0",
+        "level-hooks": ">=4.4.0 <5",
+        "string-range": "~1.2.1",
+        "xtend": "~2.0.4"
+      },
+      "dependencies": {
+        "level-fix-range": {
+          "version": "2.0.0",
+          "resolved": "https://npm.screenmeet.com/level-fix-range/-/level-fix-range-2.0.0.tgz",
+          "integrity": "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=",
+          "requires": {
+            "clone": "~0.1.9"
+          }
+        },
+        "xtend": {
+          "version": "2.0.6",
+          "resolved": "https://npm.screenmeet.com/xtend/-/xtend-2.0.6.tgz",
+          "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
+          "requires": {
+            "is-object": "~0.1.2",
+            "object-keys": "~0.2.0"
+          }
+        }
+      }
+    },
+    "levelup": {
+      "version": "0.18.6",
+      "resolved": "https://npm.screenmeet.com/levelup/-/levelup-0.18.6.tgz",
+      "integrity": "sha1-5qAcsIlhbI7MApHCqb0/DETj5es=",
+      "requires": {
+        "bl": "~0.8.1",
+        "deferred-leveldown": "~0.2.0",
+        "errno": "~0.1.1",
+        "prr": "~0.0.0",
+        "readable-stream": "~1.0.26",
+        "semver": "~2.3.1",
+        "xtend": "~3.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://npm.screenmeet.com/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "prr": {
+          "version": "0.0.0",
+          "resolved": "https://npm.screenmeet.com/prr/-/prr-0.0.0.tgz",
+          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://npm.screenmeet.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://npm.screenmeet.com/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://npm.screenmeet.com/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -594,6 +1779,79 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://npm.screenmeet.com/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://npm.screenmeet.com/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://npm.screenmeet.com/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://npm.screenmeet.com/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://npm.screenmeet.com/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://npm.screenmeet.com/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      }
+    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -609,6 +1867,16 @@
         "mime-db": "~1.33.0"
       }
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -623,6 +1891,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://npm.screenmeet.com/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://npm.screenmeet.com/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -694,8 +1981,25 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://npm.screenmeet.com/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -712,11 +2016,69 @@
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://npm.screenmeet.com/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "0.2.0",
+      "resolved": "https://npm.screenmeet.com/object-keys/-/object-keys-0.2.0.tgz",
+      "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
+      "requires": {
+        "foreach": "~2.0.1",
+        "indexof": "~0.0.1",
+        "is": "~0.2.6"
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://npm.screenmeet.com/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "octal": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/octal/-/octal-1.0.0.tgz",
+      "integrity": "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -765,11 +2127,46 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "parse-asn1": {
+      "version": "5.1.4",
+      "resolved": "https://npm.screenmeet.com/parse-asn1/-/parse-asn1-5.1.4.tgz",
+      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+      "requires": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://npm.screenmeet.com/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://npm.screenmeet.com/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://npm.screenmeet.com/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -783,11 +2180,44 @@
       "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://npm.screenmeet.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "process-es6": {
+      "version": "0.11.6",
+      "resolved": "https://npm.screenmeet.com/process-es6/-/process-es6-0.11.6.tgz",
+      "integrity": "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://npm.screenmeet.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://npm.screenmeet.com/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://npm.screenmeet.com/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -800,6 +2230,56 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://npm.screenmeet.com/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://npm.screenmeet.com/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://npm.screenmeet.com/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://npm.screenmeet.com/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://npm.screenmeet.com/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://npm.screenmeet.com/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
       "version": "2.85.0",
@@ -837,11 +2317,276 @@
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://npm.screenmeet.com/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://npm.screenmeet.com/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://npm.screenmeet.com/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "rollup": {
+      "version": "1.2.3",
+      "resolved": "https://npm.screenmeet.com/rollup/-/rollup-1.2.3.tgz",
+      "integrity": "sha512-hTWFogj/Z077imG9XRM1i43ffarWNToDgsqkU62eJRX4rJE213/c8+gUIf4xacfzytl0sjJZfCzzPQfZN7oIQg==",
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*",
+        "acorn": "^6.1.0"
+      }
+    },
+    "rollup-plugin-commonjs": {
+      "version": "9.2.1",
+      "resolved": "https://npm.screenmeet.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.1.tgz",
+      "integrity": "sha512-X0A/Cp/t+zbONFinBhiTZrfuUaVwRIp4xsbKq/2ohA2CDULa/7ONSJTelqxon+Vds2R2t2qJTqJQucKUC8GKkw==",
+      "requires": {
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.25.1",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.3.3"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://npm.screenmeet.com/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "rollup-plugin-node-builtins": {
+      "version": "2.1.2",
+      "resolved": "https://npm.screenmeet.com/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz",
+      "integrity": "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k=",
+      "requires": {
+        "browserify-fs": "^1.0.0",
+        "buffer-es6": "^4.9.2",
+        "crypto-browserify": "^3.11.0",
+        "process-es6": "^0.11.2"
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.1",
+      "resolved": "https://npm.screenmeet.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",
+      "integrity": "sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==",
+      "requires": {
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://npm.screenmeet.com/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "4.0.4",
+      "resolved": "https://npm.screenmeet.com/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
+      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.0.0",
+        "serialize-javascript": "^1.6.1",
+        "terser": "^3.14.1"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.4.1",
+      "resolved": "https://npm.screenmeet.com/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
+      "integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.0",
+          "resolved": "https://npm.screenmeet.com/estree-walker/-/estree-walker-0.6.0.tgz",
+          "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw=="
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://npm.screenmeet.com/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "semver": {
+      "version": "2.3.2",
+      "resolved": "https://npm.screenmeet.com/semver/-/semver-2.3.2.tgz",
+      "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
+    },
+    "serialize-javascript": {
+      "version": "1.6.1",
+      "resolved": "https://npm.screenmeet.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw=="
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://npm.screenmeet.com/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://npm.screenmeet.com/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://npm.screenmeet.com/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://npm.screenmeet.com/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://npm.screenmeet.com/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://npm.screenmeet.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://npm.screenmeet.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://npm.screenmeet.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://npm.screenmeet.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "sntp": {
       "version": "2.1.0",
@@ -860,6 +2605,52 @@
       "optional": true,
       "requires": {
         "amdefine": ">=0.0.4"
+      }
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://npm.screenmeet.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://npm.screenmeet.com/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://npm.screenmeet.com/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://npm.screenmeet.com/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://npm.screenmeet.com/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://npm.screenmeet.com/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -884,6 +2675,38 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://npm.screenmeet.com/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://npm.screenmeet.com/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "string-range": {
+      "version": "1.2.2",
+      "resolved": "https://npm.screenmeet.com/string-range/-/string-range-1.2.2.tgz",
+      "integrity": "sha1-qJPtNH5yKZvIO++78qaSqNI51d0="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://npm.screenmeet.com/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
@@ -899,6 +2722,28 @@
         "has-flag": "^1.0.0"
       }
     },
+    "terser": {
+      "version": "3.16.1",
+      "resolved": "https://npm.screenmeet.com/terser/-/terser-3.16.1.tgz",
+      "integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://npm.screenmeet.com/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://npm.screenmeet.com/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -906,6 +2751,44 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://npm.screenmeet.com/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://npm.screenmeet.com/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://npm.screenmeet.com/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://npm.screenmeet.com/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -942,6 +2825,16 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://npm.screenmeet.com/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedarray-to-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://npm.screenmeet.com/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
+      "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
+    },
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -968,6 +2861,89 @@
           "optional": true
         }
       }
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://npm.screenmeet.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://npm.screenmeet.com/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://npm.screenmeet.com/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://npm.screenmeet.com/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://npm.screenmeet.com/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://npm.screenmeet.com/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://npm.screenmeet.com/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://npm.screenmeet.com/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://npm.screenmeet.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",
@@ -1004,8 +2980,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "2.2.0",
+      "resolved": "https://npm.screenmeet.com/xtend/-/xtend-2.2.0.tgz",
+      "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,14 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/mtth/avsc.git"
+  },
+  "dependencies": {
+    "buffer": "^5.2.1",
+    "md5.js": "^1.3.5",
+    "rollup": "^1.2.3",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-builtins": "^2.1.2",
+    "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-terser": "^4.0.4"
   }
 }


### PR DESCRIPTION
This is more of a request for comment than a real pull request. I would like to use avsc in the browser using the packager Rollup. Currently, I could not get that to work to with the standard distribution. I did try browserify and that worked of course, but it doesn't really help me with my bundle.

I'm also trying to minimize the weight of the library. With the included build.js and rollup I could push the size down to 68k after this refactor (which is mostly neutral but may have broken one or two things)

So in this pr I removed as much node.js code as I could from lib/util and lib.types. To do that I refactored the types to the es6 class syntax to remove the dependency on util.inherits. As removing the node.js formatting and debug functions. There are two places which I added @FIXME notices where that probably broke something. I haven't run any of the tests yet.

Overall, it would be helpful if there was an esm distribution of avsc, which would probably be a different way to make this library rollup friendly. 

So what would you recommend on how to proceed?

