### PR TITLE
Rollup v2

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,29 @@
+const rollup = require('rollup');
+const resolve = require('rollup-plugin-node-resolve');
+const cjs = require('rollup-plugin-commonjs');
+const terser = require('rollup-plugin-terser').terser;
+const builtins = require('rollup-plugin-node-builtins');
+
+async function build() {
+  const avsc = await rollup.rollup({
+    input: './etc/browser/avsc-types.js',
+    plugins: [
+      builtins(),
+      //nodeglobals(),
+      resolve({browser: true /*,preferBuiltins: false*/ }),
+      cjs(),
+      terser(),
+    ]
+  })
+    
+  await avsc.write({
+    name: "leader",
+    format: 'iife',
+    file: './avsc.js',
+    sourcemap: true
+  });
+
+}
+build().catch(err => {
+  console.error(err)
+})

--- a/lib/types.js
+++ b/lib/types.js
@@ -16,13 +16,11 @@
 
 var utils = require('./utils'),
     buffer = require('buffer'), // For `SlowBuffer`.
-    util = require('util');
+    inherits = require('inherits');
 
 
 // Convenience imports.
 var Tap = utils.Tap;
-var debug = util.debuglog('avsc:types');
-var f = util.format;
 
 // All non-union concrete (i.e. non-logical) Avro types.
 var TYPES = {
@@ -99,17 +97,17 @@ function Type(schema, opts) {
       name = qualify(name, namespace);
       if (isPrimitive(name)) {
         // Avro doesn't allow redefining primitive names.
-        throw new Error(f('cannot rename primitive type: %j', name));
+        throw new Error(`cannot rename primitive type: ${JSON.stringify(name)}`);
       }
       var registry = opts && opts.registry;
       if (registry) {
         if (registry[name] !== undefined) {
-          throw new Error(f('duplicate type name: %s', name));
+          throw new Error(`duplicate type name: ${JSON.stringify(name)}`);
         }
         registry[name] = type;
       }
     } else if (opts && opts.noAnonymousTypes) {
-      throw new Error(f('missing name property in schema: %j', schema));
+      throw new Error(`missing name property in schema: ${JSON.stringify(schema)}`);
     }
     this.name = name;
     this.aliases = schema.aliases ?
@@ -140,7 +138,7 @@ Type.forSchema = function (schema, opts) {
       case 'auto':
         return undefined; // Determined dynamically later on.
       default:
-        throw new Error(f('invalid wrap unions option: %j', wrapUnions));
+        throw new Error(`invalid wrap unions option: ${JSON.stringify(wrapUnions)}`);
     }
   })(opts.wrapUnions);
 
@@ -156,7 +154,7 @@ Type.forSchema = function (schema, opts) {
   var type;
   if (opts.typeHook && (type = opts.typeHook(schema, opts))) {
     if (!Type.isType(type)) {
-      throw new Error(f('invalid typehook return value: %j', type));
+      throw new Error(`invalid typehook return value: ${JSON.stringify(type)}`);
     }
     return type;
   }
@@ -174,7 +172,7 @@ Type.forSchema = function (schema, opts) {
       // reference.
       return opts.registry[schema] = Type.forSchema({type: schema}, opts);
     }
-    throw new Error(f('undefined type name: %s', schema));
+    throw new Error(`undefined type name: ${schema}`);
   }
 
   if (schema.logicalType && opts.logicalTypes && !LOGICAL_TYPE) {
@@ -186,10 +184,10 @@ Type.forSchema = function (schema, opts) {
         registry[key] = opts.registry[key];
       });
       try {
-        debug('instantiating logical type for %s', schema.logicalType);
+        //debug('instantiating logical type for %s', schema.logicalType);
         return new DerivedType(schema, opts);
       } catch (err) {
-        debug('failed to instantiate logical type for %s', schema.logicalType);
+        //debug('failed to instantiate logical type for %s', schema.logicalType);
         if (opts.assertLogicalTypes) {
           // The spec mandates that we fall through to the underlying type if
           // the logical type is invalid. We provide this option to ease
@@ -215,7 +213,7 @@ Type.forSchema = function (schema, opts) {
     type = (function (typeName) {
       var Type = TYPES[typeName];
       if (Type === undefined) {
-        throw new Error(f('unknown type: %j', typeName));
+        throw new Error(`unknown type: ${JSON.stringify(typeName)}`);
       }
       return new Type(schema, opts);
     })(schema.type);
@@ -236,7 +234,7 @@ Type.forValue = function (val, opts) {
     var type = opts.valueHook(val, opts);
     if (type !== undefined) {
       if (!Type.isType(type)) {
-        throw new Error(f('invalid value hook return value: %j', type));
+        throw new Error(`invalid value hook return value: ${JSON.stringify(type)}`);
       }
       return type;
     }
@@ -288,7 +286,7 @@ Type.forValue = function (val, opts) {
         })
       }, opts);
     default:
-      throw new Error(f('cannot infer type from: %j', val));
+      throw new Error(`cannot infer type from: ${JSON.stringify(val)}`);
   }
 };
 
@@ -446,7 +444,7 @@ Type.isType = function (/* any, [prefix] ... */) {
 };
 
 Type.__reset = function (size) {
-  debug('resetting type buffer to %d', size);
+  //debug('resetting type buffer to %d', size);
   TAP.buf = new buffer.SlowBuffer(size);
 };
 
@@ -491,7 +489,7 @@ Type.prototype.createResolver = function (type, opts) {
   if (!Type.isType(type)) {
     // More explicit error message than the "incompatible type" thrown
     // otherwise (especially because of the overridden `toJSON` method).
-    throw new Error(f('not a type: %j', type));
+    throw new Error(`not a type: ${JSON.stringify(type)}`);
   }
 
   if (!Type.isType(this, 'union', 'logical') && Type.isType(type, 'logical')) {
@@ -530,7 +528,7 @@ Type.prototype.createResolver = function (type, opts) {
       var index = tap.readLong();
       var resolver = resolvers[index];
       if (resolver === undefined) {
-        throw new Error(f('invalid union index: %s', index));
+        throw new Error(`invalid union index: ${index}`);
       }
       return resolvers[index]._read(tap);
     };
@@ -539,7 +537,7 @@ Type.prototype.createResolver = function (type, opts) {
   }
 
   if (!resolver._read) {
-    throw new Error(f('cannot read %s as %s', type, this));
+    throw new Error(`cannot read ${type} as ${this}`);
   }
   return Object.freeze(resolver);
 };
@@ -604,14 +602,14 @@ Type.prototype.inspect = function () {
   var className = getClassName(typeName);
   if (isPrimitive(typeName)) {
     // The class name is sufficient to identify the type.
-    return f('<%s>', className);
+    return `<${className}>`;
   } else {
     // We add a little metadata for convenience.
     var obj = this.schema({exportAttrs: true, noDeref: true});
     if (typeof obj == 'object' && !Type.isType(this, 'logical')) {
       obj.type = undefined; // Would be redundant with constructor name.
     }
-    return f('<%s %j>', className, obj);
+    return `<${className} ${JSON.stringify(obj)}>`;
   }
 };
 
@@ -771,7 +769,7 @@ function PrimitiveType(noFreeze) {
     Object.freeze(this);
   }
 }
-util.inherits(PrimitiveType, Type);
+inherits(PrimitiveType, Type);
 
 PrimitiveType.prototype._update = function (resolver, type) {
   if (type.typeName === this.typeName) {
@@ -790,7 +788,7 @@ PrimitiveType.prototype.compare = utils.compare;
 
 /** Nulls. */
 function NullType() { PrimitiveType.call(this); }
-util.inherits(NullType, PrimitiveType);
+inherits(NullType, PrimitiveType);
 
 NullType.prototype._check = function (val, flags, hook) {
   var b = val === null;
@@ -820,7 +818,7 @@ NullType.prototype.random = NullType.prototype._read;
 
 /** Booleans. */
 function BooleanType() { PrimitiveType.call(this); }
-util.inherits(BooleanType, PrimitiveType);
+inherits(BooleanType, PrimitiveType);
 
 BooleanType.prototype._check = function (val, flags, hook) {
   var b = typeof val == 'boolean';
@@ -851,7 +849,7 @@ BooleanType.prototype.random = function () { return RANDOM.nextBoolean(); };
 
 /** Integers. */
 function IntType() { PrimitiveType.call(this); }
-util.inherits(IntType, PrimitiveType);
+inherits(IntType, PrimitiveType);
 
 IntType.prototype._check = function (val, flags, hook) {
   var b = val === (val | 0);
@@ -889,7 +887,7 @@ IntType.prototype.random = function () { return RANDOM.nextInt(1000) | 0; };
  * `AbstractLongType` below for a way to implement a custom long type.
  */
 function LongType() { PrimitiveType.call(this); }
-util.inherits(LongType, PrimitiveType);
+inherits(LongType, PrimitiveType);
 
 LongType.prototype._check = function (val, flags, hook) {
   var b = typeof val == 'number' && val % 1 === 0 && isSafeLong(val);
@@ -951,7 +949,7 @@ LongType.__with = function (methods, noUnpack) {
   var type = new AbstractLongType(noUnpack);
   Object.keys(mapping).forEach(function (name) {
     if (methods[name] === undefined) {
-      throw new Error(f('missing method implementation: %s', name));
+      throw new Error(`missing method implementation: ${name}`);
     }
     type[mapping[name]] = methods[name];
   });
@@ -960,7 +958,7 @@ LongType.__with = function (methods, noUnpack) {
 
 /** Floats. */
 function FloatType() { PrimitiveType.call(this); }
-util.inherits(FloatType, PrimitiveType);
+inherits(FloatType, PrimitiveType);
 
 FloatType.prototype._check = function (val, flags, hook) {
   var b = typeof val == 'number';
@@ -1005,7 +1003,7 @@ FloatType.prototype.random = function () { return RANDOM.nextFloat(1e3); };
 
 /** Doubles. */
 function DoubleType() { PrimitiveType.call(this); }
-util.inherits(DoubleType, PrimitiveType);
+inherits(DoubleType, PrimitiveType);
 
 DoubleType.prototype._check = function (val, flags, hook) {
   var b = typeof val == 'number';
@@ -1051,7 +1049,7 @@ DoubleType.prototype.random = function () { return RANDOM.nextFloat(); };
 
 /** Strings. */
 function StringType() { PrimitiveType.call(this); }
-util.inherits(StringType, PrimitiveType);
+inherits(StringType, PrimitiveType);
 
 StringType.prototype._check = function (val, flags, hook) {
   var b = typeof val == 'string';
@@ -1100,7 +1098,7 @@ StringType.prototype.random = function () {
  * Note the coercion in `_copy`.
  */
 function BytesType() { PrimitiveType.call(this); }
-util.inherits(BytesType, PrimitiveType);
+inherits(BytesType, PrimitiveType);
 
 BytesType.prototype._check = function (val, flags, hook) {
   var b = Buffer.isBuffer(val);
@@ -1135,14 +1133,14 @@ BytesType.prototype._copy = function (obj, opts) {
       return obj.toString('binary');
     case 2: // Coerce strings to buffers.
       if (typeof obj != 'string') {
-        throw new Error(f('cannot coerce to buffer: %j', obj));
+        throw new Error(`cannot coerce to buffer: ${JSON.stringify(obj)}`);
       }
       buf = utils.bufferFrom(obj, 'binary');
       this._check(buf, undefined, throwInvalidError);
       return buf;
     case 1: // Coerce buffer JSON representation to buffers.
       if (!isJsonBuffer(obj)) {
-        throw new Error(f('cannot coerce to buffer: %j', obj));
+        throw new Error(`cannot coerce to buffer: ${JSON.stringify(obj)}`);
       }
       buf = utils.bufferFrom(obj.data);
       this._check(buf, undefined, throwInvalidError);
@@ -1166,7 +1164,7 @@ function UnionType(schema, opts) {
   Type.call(this);
 
   if (!Array.isArray(schema)) {
-    throw new Error(f('non-array union schema: %j', schema));
+    throw new Error(`non-array union schema: ${JSON.stringify(schema)}`);
   }
   if (!schema.length) {
     throw new Error('empty union');
@@ -1182,12 +1180,12 @@ function UnionType(schema, opts) {
     }
     var branch = type.branchName;
     if (this._branchIndices[branch] !== undefined) {
-      throw new Error(f('duplicate union branch name: %j', branch));
+      throw new Error(`duplicate union branch name: ${JSON.stringify(branch)}`);
     }
     this._branchIndices[branch] = i;
   }, this);
 }
-util.inherits(UnionType, Type);
+inherits(UnionType, Type);
 
 UnionType.prototype._branchConstructor = function () {
   throw new Error('unions cannot be directly wrapped');
@@ -1246,7 +1244,7 @@ function UnwrappedUnionType(schema, opts) {
     } else {
       var bucket = getTypeBucket(type);
       if (this._bucketIndices[bucket] !== undefined) {
-        throw new Error(f('ambiguous unwrapped union: %j', this));
+        throw new Error(`ambiguous unwrapped union: ${JSON.stringify(this)}`);
       }
       this._bucketIndices[bucket] = index;
     }
@@ -1254,7 +1252,7 @@ function UnwrappedUnionType(schema, opts) {
 
   Object.freeze(this);
 }
-util.inherits(UnwrappedUnionType, UnionType);
+inherits(UnwrappedUnionType, UnionType);
 
 UnwrappedUnionType.prototype._getIndex = function (val) {
   var index = this._bucketIndices[getValueBucket(val)];
@@ -1302,7 +1300,7 @@ UnwrappedUnionType.prototype._read = function (tap) {
   if (branchType) {
     return branchType._read(tap);
   } else {
-    throw new Error(f('invalid union index: %s', index));
+    throw new Error(`invalid union index: ${index}`);
   }
 };
 
@@ -1431,7 +1429,7 @@ function WrappedUnionType(schema, opts) {
   UnionType.call(this, schema, opts);
   Object.freeze(this);
 }
-util.inherits(WrappedUnionType, UnionType);
+inherits(WrappedUnionType, UnionType);
 
 WrappedUnionType.prototype._check = function (val, flags, hook, path) {
   var b = false;
@@ -1467,7 +1465,7 @@ WrappedUnionType.prototype._check = function (val, flags, hook, path) {
 WrappedUnionType.prototype._read = function (tap) {
   var type = this.types[tap.readLong()];
   if (!type) {
-    throw new Error(f('invalid union index'));
+    throw new Error('invalid union index');
   }
   var Branch = type._branchConstructor;
   if (Branch === null) {
@@ -1617,23 +1615,23 @@ WrappedUnionType.prototype.random = function () {
 function EnumType(schema, opts) {
   Type.call(this, schema, opts);
   if (!Array.isArray(schema.symbols) || !schema.symbols.length) {
-    throw new Error(f('invalid enum symbols: %j', schema.symbols));
+    throw new Error(`invalid enum symbols: ${JSON.stringify(schema.symbols)}`);
   }
   this.symbols = Object.freeze(schema.symbols.slice());
   this._indices = {};
   this.symbols.forEach(function (symbol, i) {
     if (!isValidName(symbol)) {
-      throw new Error(f('invalid %s symbol: %j', this, symbol));
+      throw new Error(`invalid ${this} symbol: ${JSON.stringify(symbol)}`);
     }
     if (this._indices[symbol] !== undefined) {
-      throw new Error(f('duplicate %s symbol: %j', this, symbol));
+      throw new Error(`duplicate ${this} symbol: ${JSON.stringify(symbol)}`);
     }
     this._indices[symbol] = i;
   }, this);
   this._branchConstructor = this._createBranchConstructor();
   Object.freeze(this);
 }
-util.inherits(EnumType, Type);
+inherits(EnumType, Type);
 
 EnumType.prototype._check = function (val, flags, hook) {
   var b = this._indices[val] !== undefined;
@@ -1647,7 +1645,7 @@ EnumType.prototype._read = function (tap) {
   var index = tap.readLong();
   var symbol = this.symbols[index];
   if (symbol === undefined) {
-    throw new Error(f('invalid %s enum index: %s', this.name, index));
+    throw new Error(`invalid ${this.name} enum index: ${index}`);
   }
   return symbol;
 };
@@ -1703,13 +1701,13 @@ EnumType.prototype.random = function () {
 function FixedType(schema, opts) {
   Type.call(this, schema, opts);
   if (schema.size !== (schema.size | 0) || schema.size < 1) {
-    throw new Error(f('invalid %s size', this.branchName));
+    throw new Error(`invalid ${this.branchName} size`);
   }
   this.size = schema.size | 0;
   this._branchConstructor = this._createBranchConstructor();
   Object.freeze(this);
 }
-util.inherits(FixedType, Type);
+inherits(FixedType, Type);
 
 FixedType.prototype._check = function (val, flags, hook) {
   var b = Buffer.isBuffer(val) && val.length === this.size;
@@ -1767,13 +1765,13 @@ FixedType.prototype.random = function () {
 function MapType(schema, opts) {
   Type.call(this);
   if (!schema.values) {
-    throw new Error(f('missing map values: %j', schema));
+    throw new Error(`missing map values: ${JSON.stringify(schema)}`);
   }
   this.valuesType = Type.forSchema(schema.values, opts);
   this._branchConstructor = this._createBranchConstructor();
   Object.freeze(this);
 }
-util.inherits(MapType, Type);
+inherits(MapType, Type);
 
 MapType.prototype._check = function (val, flags, hook, path) {
   if (!val || typeof val != 'object' || Array.isArray(val)) {
@@ -1905,13 +1903,13 @@ MapType.prototype._deref = function (schema, opts) {
 function ArrayType(schema, opts) {
   Type.call(this);
   if (!schema.items) {
-    throw new Error(f('missing array items: %j', schema));
+    throw new Error(`missing array items: ${JSON.stringify(schema)}`);
   }
   this.itemsType = Type.forSchema(schema.items, opts);
   this._branchConstructor = this._createBranchConstructor();
   Object.freeze(this);
 }
-util.inherits(ArrayType, Type);
+inherits(ArrayType, Type);
 
 ArrayType.prototype._check = function (val, flags, hook, path) {
   if (!Array.isArray(val)) {
@@ -2092,10 +2090,10 @@ function RecordType(schema, opts) {
   Type.call(this, schema, opts);
 
   if (!Array.isArray(schema.fields)) {
-    throw new Error(f('non-array record fields: %j', schema.fields));
+    throw new Error(`non-array record fields: ${JSON.stringify(schema.fields)}`);
   }
   if (utils.hasDuplicates(schema.fields, function (f) { return f.name; })) {
-    throw new Error(f('duplicate field name: %j', schema.fields));
+    throw new Error(`duplicate field name: ${JSON.stringify(schema.fields)}`);
   }
   this._fieldsByName = {};
   this.fields = Object.freeze(schema.fields.map(function (f) {
@@ -2114,7 +2112,7 @@ function RecordType(schema, opts) {
   opts.namespace = namespace;
   Object.freeze(this);
 }
-util.inherits(RecordType, Type);
+inherits(RecordType, Type);
 
 RecordType.prototype._getConstructorName = function () {
   return this.name ?
@@ -2175,7 +2173,7 @@ RecordType.prototype._createConstructor = function (errorStackTraces) {
   Record.getType = function () { return self; };
   Record.type = self;
   if (this._isError) {
-    util.inherits(Record, Error);
+    inherits(Record, Error);
     Record.prototype.name = this._getConstructorName();
   }
   Record.prototype.clone = function (o) { return self.clone(this, o); };
@@ -2314,7 +2312,7 @@ RecordType.prototype._createWriter = function () {
 RecordType.prototype._update = function (resolver, type, opts) {
   // jshint -W054
   if (type.name && !~getAliases(this).indexOf(type.name)) {
-    throw new Error(f('no alias found for %s', type.name));
+    throw new Error(`no alias found for ${type.name}`);
   }
 
   var rFields = this.fields;
@@ -2336,13 +2334,13 @@ RecordType.prototype._update = function (resolver, type, opts) {
     }
     if (matches.length > 1) {
       throw new Error(
-        f('ambiguous aliasing for %s.%s (%s)', type.name, field.name, matches)
+        `ambiguous aliasing for ${type.name}.${field.name} (${matches})`
       );
     }
     if (!matches.length) {
       if (field.defaultValue() === undefined) {
         throw new Error(
-          f('no matching field for default-less %s.%s', type.name, field.name)
+          'no matching field for default-less ${type.name}.${field.name}'
         );
       }
       innerArgs.push('undefined');
@@ -2557,7 +2555,7 @@ function LogicalType(schema, opts) {
   // We don't freeze derived types to allow arbitrary properties. Implementors
   // can still do so in the subclass' constructor at their convenience.
 }
-util.inherits(LogicalType, Type);
+inherits(LogicalType, Type);
 
 Object.defineProperty(LogicalType.prototype, 'typeName', {
   enumerable: true,
@@ -2685,7 +2683,7 @@ function AbstractLongType(noUnpack) {
   // frozen.
   this._noUnpack = !!noUnpack;
 }
-util.inherits(AbstractLongType, LongType);
+inherits(AbstractLongType, LongType);
 
 AbstractLongType.prototype.typeName = 'abstract:long';
 
@@ -2767,7 +2765,7 @@ AbstractLongType.prototype.compare = utils.abstractFunction;
 function Field(schema, opts) {
   var name = schema.name;
   if (typeof name != 'string' || !isValidName(name)) {
-    throw new Error(f('invalid field name: %s', name));
+    throw new Error(`invalid field name: ${name}`);
   }
 
   this.name = name;
@@ -2784,7 +2782,7 @@ function Field(schema, opts) {
       case 'ignore':
         return 0;
       default:
-        throw new Error(f('invalid order: %j', order));
+        throw new Error(`invalid order: ${JSON.stringify(order)}`);
     }
   })(schema.order === undefined ? 'ascending' : schema.order);
 
@@ -2895,7 +2893,7 @@ function qualify(name, namespace) {
   }
   name.split('.').forEach(function (part) {
     if (!isValidName(part)) {
-      throw new Error(f('invalid name: %j', name));
+      throw new Error(`invalid name: ${JSON.stringify(name)}`);
     }
   });
   var tail = unqualify(name);
@@ -3012,7 +3010,7 @@ function isValidName(str) { return NAME_PATTERN.test(str); }
  * with a hook since the path is not propagated (for efficiency reasons).
  */
 function throwInvalidError(val, type) {
-  throw new Error(f('invalid %s: %j', type, val));
+  throw new Error(`invalid ${type}: ${JSON.stringify(val)}`);
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,8 +7,7 @@
 
 /** Various utilities used across this library. */
 
-var crypto = require('crypto');
-var util = require('util');
+var md5 = require('jshashes').MD5;
 
 // Shared buffer pool for all taps.
 var POOL = new BufferPool(4096);
@@ -76,11 +75,9 @@ function getOption(opts, key, def) {
  * @param str {String} The string to hash.
  * @param algorithm {String} The algorithm used. Defaults to MD5.
  */
-function getHash(str, algorithm) {
-  algorithm = algorithm || 'md5';
-  var hash = crypto.createHash(algorithm);
-  hash.end(str);
-  return hash.read();
+function getHash(str) {
+  var hash = new md5();
+  return hash.hex(str);
 }
 
 /**
@@ -242,10 +239,7 @@ function addDeprecatedGetters(obj, props) {
   for (i = 0, l = props.length; i < l; i++) {
     prop = props[i];
     getter = 'get' + capitalize(prop);
-    proto[getter] = util.deprecate(
-      createGetter(prop),
-      'use `.' + prop + '` instead of `.' + getter + '()`'
-    );
+    proto[getter] = createGetter(prop)
   }
 
   function createGetter(prop) {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "coveralls": "^3.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
+    "rollup": "^1.6.0",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-builtins": "^2.1.2",
+    "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-terser": "^4.0.4",
     "tmp": "^0.0.33"
   },
   "author": {
@@ -65,5 +70,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/mtth/avsc.git"
+  },
+  "dependencies": {
+    "inherits": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "url": "git://github.com/mtth/avsc.git"
   },
   "dependencies": {
-    "inherits": "^2.0.3"
+    "inherits": "^2.0.3",
+    "jshashes": "^1.0.7"
   }
 }


### PR DESCRIPTION
Following up from #224 this is the more minimal refactor. I'm fairly certain it did not improve the rolled up size much, however, this was sufficient that I could actually bundle it with my project. Now I'm unblocked to use avsc without making a separate browserify bundle.

One of the big issues was the crypto library. Apparently, it seems the [rollup-plugin-node-builtins](https://www.npmjs.com/package/rollup-plugin-node-builtins) has trouble with the crypto module and I tried out md5.js but it had a different issue being packaged because of some circular dependency. Jshashes is entirely self contained and it was bundle-able.

Maybe someone else will find this useful.