### PR TITLE
isSafeLong now accepts int64 length

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -2984,7 +2984,7 @@ function readArraySize(tap) {
  * + We must remove one from each bound because of rounding errors.
  */
 function isSafeLong(n) {
-  return n >= -9007199254740990 && n <= 9007199254740990;
+  return n >= -9223372036854775808 && n <= 9223372036854775807;
 }
 
 /**


### PR DESCRIPTION
When topics have dates encoded as Int64 and are nanoseconds since Epoch, the length is then 19 digits long exceeding the current min/max as defined in isSafeLong. Changed isSafeLong to return true when long is within range outlined here, https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/integral-types-table