### PR TITLE
Add type defs for TransportFunction

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -238,7 +238,10 @@ export namespace Service {
     objectMode: boolean;
   }
 
-  type TransportFunction = () => void; // TODO
+  
+
+  type TransportFunctionCallback = (err: Error|null|undefined, res?: stream.Stream) => void;
+  type TransportFunction = (cb: TransportFunctionCallback) => stream.Stream; // TODO
 
   type Transport = stream.Duplex | TransportFunction;
 


### PR DESCRIPTION
These were `TODO` so I had a go at adding them as it
was casuing some ugliness when I used avsc from Typescript.

These seem to be correct, and definitely work for me, but it
would be great if someone more familar with the codebase
could check my work :-)

It would have been nice to also constrain the type of
streams further depending on whether the transport would
be read, write, or duplex. I had a quick look at this but
it turned out to be a larger change so I decided to back
off and go with a smaller diff.