### PR TITLE
Allow idl files to recognize default values on enums

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -478,6 +478,10 @@ Reader.prototype._readEnum = function (schema) {
   do {
     schema.symbols.push(tk.next().val);
   } while (!tk.next({val: '}', silent: true}) && tk.next({val: ','}));
+
+  if (tk.next({val: '=', silent: true})) {
+    schema.default = tk.next().val;
+  }
   return schema;
 };
 

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -481,6 +481,7 @@ Reader.prototype._readEnum = function (schema) {
 
   if (tk.next({val: '=', silent: true})) {
     schema.default = tk.next().val;
+    tk.next({val: ';'});
   }
   return schema;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avsc",
-  "version": "5.4.12",
+  "version": "5.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avsc",
-  "version": "5.4.13",
+  "version": "5.4.14",
   "description": "Avro for JavaScript",
   "homepage": "https://github.com/mtth/avsc",
   "keywords": [

--- a/test/dat/Hello.avdl
+++ b/test/dat/Hello.avdl
@@ -16,7 +16,14 @@ protocol Simple {
     FOO,
     BAR, // the bar enum value
     BAZ
-  } = BAZ
+  }
+
+/** An enum with a default value. */
+  enum Letters {
+    A,
+    B,
+    C
+  } = A;
 
   /** A fixed. */
   fixed MD5(16);

--- a/test/dat/Hello.avdl
+++ b/test/dat/Hello.avdl
@@ -16,7 +16,7 @@ protocol Simple {
     FOO,
     BAR, // the bar enum value
     BAZ
-  }
+  } = BAZ
 
   /** A fixed. */
   fixed MD5(16);

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -41,7 +41,8 @@ suite('specs', function () {
               doc: 'An enum.',
               type: 'enum',
               name: 'Kind',
-              symbols: ['FOO', 'BAR', 'BAZ']
+              symbols: ['FOO', 'BAR', 'BAZ'],
+              default: 'BAZ'
             },
             {type: 'fixed', doc: 'A fixed.', name: 'MD5', size: 16},
             {

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -41,8 +41,14 @@ suite('specs', function () {
               doc: 'An enum.',
               type: 'enum',
               name: 'Kind',
-              symbols: ['FOO', 'BAR', 'BAZ'],
-              default: 'BAZ'
+              symbols: ['FOO', 'BAR', 'BAZ']
+            },
+            {
+              doc: 'An enum with a default value.',
+              type: 'enum',
+              name: 'Letters',
+              symbols: ['A', 'B', 'C'],
+              default: 'A'
             },
             {type: 'fixed', doc: 'A fixed.', name: 'MD5', size: 16},
             {


### PR DESCRIPTION
I realized that the package does not support Avro 1.9.0 Specification yet, but I wanted to open up this PR to allow the parsing of files to not error at the very least when it sees default values for enums. https://avro.apache.org/docs/current/spec.html#Enums.

At a minimum, this will allow the parsing of a file to continue without a failure because of an unrecognized token. If you wish to add the ability to recognize and use the default value, it will take a little bit more time on my end.