### PR TITLE
Convert undefined to null type when writing

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1316,7 +1316,7 @@ UnwrappedUnionType.prototype._read = function (tap) {
 UnwrappedUnionType.prototype._write = function (tap, val) {
   var index = this._getIndex(val);
   if (index === undefined) {
-    throwInvalidError(val, this);
+    val = null;
   }
   tap.writeLong(index);
   if (val !== null) {


### PR DESCRIPTION
This PR allows the usage of nullable types using the default type undefined, preventing the error when serializing:

`Error: invalid ["null","string"]: undefined`

Basically this converts one to the other.