### PR TITLE
Don't add redundant namespaces to types

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -120,12 +120,13 @@ function assembleProtocol(fpath, opts, cb) {
       cb(err);
       return;
     }
+
     // Merge  first the types (where we don't need to check for duplicates
     // since instantiating the service will take care of it), then the messages
     // (where we need to, as duplicates will overwrite each other).
     (importedSchema.types || []).forEach(function (typeSchema) {
-      // Ensure the imported protocol's namespace is inherited correctly (it
-      // might be different from the current one).
+      // Ensure the imported protocol's namespace is inherited correctly if it is different
+      // from the current one.
       if (typeSchema.namespace === undefined) {
         var namespace = importedSchema.namespace;
         if (!namespace) {
@@ -134,7 +135,10 @@ function assembleProtocol(fpath, opts, cb) {
             namespace = match[1];
           }
         }
-        typeSchema.namespace = namespace || '';
+
+        if (namespace !== protocol.namespace && namespace != null) {
+          typeSchema.namespace = namespace
+        }
       }
       importedTypes.push(typeSchema);
     });

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -238,8 +238,8 @@ suite('specs', function () {
         assert.strictEqual(err, null);
         assert.deepEqual(schema, {
           protocol: 'First',
-          messages: {two: {request: [], response: 'int'}},
-          types: [{name: 'Foo', type: 'fixed', size: 1, namespace: ''}]
+          messages: { two: { request: [], response: 'int' } },
+          types: [{ name: 'Foo', type: 'fixed', size: 1 }]
         });
         done();
       });
@@ -256,7 +256,7 @@ suite('specs', function () {
       assembleProtocol('3.avdl', opts, function (err, schema) {
         assert.strictEqual(err, null);
         assert.strictEqual(schema.types.find(type => type.name === "Baz").namespace, "com.example.different")
-        assert.strictEqual(schema.types.find(type => type.name === "Foo").namespace, null)
+        assert.strictEqual(schema.types.find(type => type.name === "Foo").namespace, undefined)
         done();
       })
     })
@@ -284,8 +284,8 @@ suite('specs', function () {
         assert.deepEqual(schema, {
           protocol: 'A',
           types: [
-            {name: 'Letter', type: 'enum', symbols: ['A'], namespace: ''},
-            {name: 'Number', type: 'enum', symbols: ['ONE'], namespace: ''}
+            { name: 'Letter', type: 'enum', symbols: ['A'] },
+            { name: 'Number', type: 'enum', symbols: ['ONE'] }
           ]
         });
         done();
@@ -308,9 +308,9 @@ suite('specs', function () {
         assert.strictEqual(err, null);
         assert.deepEqual(schema, {
           protocol: 'A',
-          messages: {ping: {request: [], response: 'boolean'}},
+          messages: { ping: { request: [], response: 'boolean' } },
           types: [
-            {name: 'Letter', type: 'enum', symbols: ['A'], namespace: ''}
+            { name: 'Letter', type: 'enum', symbols: ['A'] }
           ]
         });
         done();
@@ -392,7 +392,7 @@ suite('specs', function () {
         assert.deepEqual(schema, {
           protocol: 'A',
           types: [
-            {name: 'Number', type: 'enum', symbols: ['1'], namespace: ''}
+            { name: 'Number', type: 'enum', symbols: ['1'] }
           ]
         });
         done();

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -245,6 +245,22 @@ suite('specs', function () {
       });
     });
 
+    test('imported types get namespace only when not equal to enclosing namespace', function (done) {
+      var opts = {
+        importHook: createImportHook({
+          '1.avdl': '@namespace("com.example.test")\nprotocol First { record Foo { string foo; } }',
+          '2.avdl': '@namespace("com.example.different")\nprotocol Different { record Baz { string baz; } }',
+          '3.avdl': '@namespace("com.example.test")\nprotocol Second { import idl "1.avdl";\nimport idl "2.avdl";\nrecord Bar { string bar; com.example.test.Foo foo; com.example.different.Baz baz; } }'
+        })
+      }
+      assembleProtocol('3.avdl', opts, function (err, schema) {
+        assert.strictEqual(err, null);
+        assert.strictEqual(schema.types.find(type => type.name === "Baz").namespace, "com.example.different")
+        assert.strictEqual(schema.types.find(type => type.name === "Foo").namespace, null)
+        done();
+      })
+    })
+
     test('duplicate message from import', function (done) {
       var hook = createImportHook({
         '1.avdl': 'import idl "2.avdl";\nprotocol First { double one(); }',


### PR DESCRIPTION
(Eventually fixes #281)

I believe this works, but I'm not sure what the appropriate behavior is with nested imports. There is a currently failing test that illustrates this well.

If it is correct that we should reset the namespace on any nested imports, the question becomes how to do that with the recursive nature of `assembleProtocol`. I would need to have a reference to the top level protocol.