### PR TITLE
feat: add sample method to generate a predictive sample value of a type

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1424,11 +1424,10 @@ UnwrappedUnionType.prototype.random = function () {
   return this.types[index].random();
 };
 
+
 UnwrappedUnionType.prototype.sample = function () {
-  var index = this.types.findIndex(function(type) {
-    return type.typeName !== 'null'
-  })
-  return this.types[index === -1 ? 0 : index].sample();
+  var index = utils.tryTofindANotNullTypeIndex(this.types);
+  return this.types[index].sample();
 };
 
 /**
@@ -1627,10 +1626,8 @@ WrappedUnionType.prototype.random = function () {
 };
 
 WrappedUnionType.prototype.sample = function () {
-  var index = this.types.findIndex(function(type) {
-    return type.typeName !== 'null'
-  })
-  var type = this.types[index === -1 ? 0 : index];
+  var index = utils.tryTofindANotNullTypeIndex(this.types);
+  var type = this.types[index];
   var Branch = type._branchConstructor;
   if (!Branch) {
     return null;

--- a/lib/types.js
+++ b/lib/types.js
@@ -637,6 +637,7 @@ Type.prototype.isValid = function (val, opts) {
 };
 
 Type.prototype.random = utils.abstractFunction;
+Type.prototype.sample = utils.abstractFunction;
 
 Type.prototype.schema = function (opts) {
   // Copy the options to avoid mutating the original options object when we add
@@ -824,6 +825,7 @@ NullType.prototype.compare = NullType.prototype._match;
 NullType.prototype.typeName = 'null';
 
 NullType.prototype.random = NullType.prototype._read;
+NullType.prototype.sample = NullType.prototype._read;
 
 /** Booleans. */
 function BooleanType() { PrimitiveType.call(this); }
@@ -855,6 +857,7 @@ BooleanType.prototype._match = function (tap1, tap2) {
 BooleanType.prototype.typeName = 'boolean';
 
 BooleanType.prototype.random = function () { return RANDOM.nextBoolean(); };
+BooleanType.prototype.sample = function () { return true };
 
 /** Integers. */
 function IntType() { PrimitiveType.call(this); }
@@ -886,6 +889,7 @@ IntType.prototype._match = function (tap1, tap2) {
 IntType.prototype.typeName = 'int';
 
 IntType.prototype.random = function () { return RANDOM.nextInt(1000) | 0; };
+IntType.prototype.sample = function () { return 0; };
 
 /**
  * Longs.
@@ -941,6 +945,7 @@ LongType.prototype._update = function (resolver, type) {
 LongType.prototype.typeName = 'long';
 
 LongType.prototype.random = function () { return RANDOM.nextInt(); };
+LongType.prototype.sample = function () { return 0; };
 
 LongType.__with = function (methods, noUnpack) {
   methods = methods || {}; // Will give a more helpful error message.
@@ -1009,6 +1014,7 @@ FloatType.prototype._update = function (resolver, type) {
 FloatType.prototype.typeName = 'float';
 
 FloatType.prototype.random = function () { return RANDOM.nextFloat(1e3); };
+FloatType.prototype.sample = function () { return 0.1; };
 
 /** Doubles. */
 function DoubleType() { PrimitiveType.call(this); }
@@ -1055,6 +1061,7 @@ DoubleType.prototype._update = function (resolver, type) {
 DoubleType.prototype.typeName = 'double';
 
 DoubleType.prototype.random = function () { return RANDOM.nextFloat(); };
+DoubleType.prototype.sample = function () { return 0.1; };
 
 /** Strings. */
 function StringType() { PrimitiveType.call(this); }
@@ -1096,6 +1103,7 @@ StringType.prototype.typeName = 'string';
 StringType.prototype.random = function () {
   return RANDOM.nextString(RANDOM.nextInt(32));
 };
+StringType.prototype.sample = function () { return "string"; };
 
 /**
  * Bytes.
@@ -1167,6 +1175,8 @@ BytesType.prototype.typeName = 'bytes';
 BytesType.prototype.random = function () {
   return RANDOM.nextBuffer(RANDOM.nextInt(32));
 };
+
+BytesType.prototype.sample = function () { return utils.bufferFrom([256]) };
 
 /** Base "abstract" Avro union type. */
 function UnionType(schema, opts) {
@@ -1414,6 +1424,13 @@ UnwrappedUnionType.prototype.random = function () {
   return this.types[index].random();
 };
 
+UnwrappedUnionType.prototype.sample = function () {
+  var index = this.types.findIndex(function(type) {
+    return type.typeName !== 'null'
+  })
+  return this.types[index === -1 ? 0 : index].sample();
+};
+
 /**
  * Compatible union type.
  *
@@ -1609,6 +1626,18 @@ WrappedUnionType.prototype.random = function () {
   return new Branch(type.random());
 };
 
+WrappedUnionType.prototype.sample = function () {
+  var index = this.types.findIndex(function(type) {
+    return type.typeName !== 'null'
+  })
+  var type = this.types[index === -1 ? 0 : index];
+  var Branch = type._branchConstructor;
+  if (!Branch) {
+    return null;
+  }
+  return new Branch(type.sample());
+};
+
 /**
  * Avro enum type.
  *
@@ -1706,6 +1735,10 @@ EnumType.prototype.random = function () {
   return RANDOM.choice(this.symbols);
 };
 
+EnumType.prototype.sample = function () {
+  return this.symbols[0];
+};
+
 /** Avro fixed type. Represented simply as a `Buffer`. */
 function FixedType(schema, opts) {
   Type.call(this, schema, opts);
@@ -1768,6 +1801,15 @@ FixedType.prototype.typeName = 'fixed';
 
 FixedType.prototype.random = function () {
   return RANDOM.nextBuffer(this.size);
+};
+
+FixedType.prototype.sample = function () {
+    var arr = [];
+    var i;
+    for (i = 0; i < this.size; i++) {
+        arr.push(256);
+    }
+    return utils.bufferFrom(arr);
 };
 
 /** Avro map. Represented as vanilla objects. */
@@ -1902,6 +1944,12 @@ MapType.prototype.random = function () {
     val[RANDOM.nextString(RANDOM.nextInt(20))] = this.valuesType.random();
   }
   return val;
+};
+
+MapType.prototype.sample = function () {
+    return {
+        aKey: this.valuesType.sample()
+    }
 };
 
 MapType.prototype._deref = function (schema, opts) {
@@ -2062,6 +2110,10 @@ ArrayType.prototype.random = function () {
     arr.push(this.itemsType.random());
   }
   return arr;
+};
+
+ArrayType.prototype.sample = function () {
+  return [this.itemsType.sample()];
 };
 
 /**
@@ -2520,6 +2572,15 @@ RecordType.prototype.random = function () {
   return new (Record.bind.apply(Record, fields))();
 };
 
+
+RecordType.prototype.sample = function () {
+  // jshint -W058
+  var fields = this.fields.map(function (f) { return f.type.sample(); });
+  fields.unshift(undefined);
+  var Record = this.recordConstructor;
+  return new (Record.bind.apply(Record, fields))();
+};
+
 RecordType.prototype.field = function (name) {
   return this._fieldsByName[name];
 };
@@ -2646,6 +2707,10 @@ LogicalType.prototype.random = function () {
   return this._fromValue(this.underlyingType.random());
 };
 
+LogicalType.prototype.sample = function () {
+  return this._fromValue(this.underlyingType.sample());
+};
+
 LogicalType.prototype._deref = function (schema, opts) {
   var type = this.underlyingType;
   var isVisited = type.name !== undefined && opts.derefed[type.name];
@@ -2761,6 +2826,10 @@ AbstractLongType.prototype._update = function (resolver, type) {
 
 AbstractLongType.prototype.random = function () {
   return this._fromJSON(LongType.prototype.random());
+};
+
+AbstractLongType.prototype.sample = function () {
+  return this._fromJSON(LongType.prototype.sample());
 };
 
 // Methods to be implemented by the user.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -882,6 +882,14 @@ function invert(buf, len) {
   }
 }
 
+function tryTofindANonNullTypeIndex(types) {
+  for (var i = 0; i < types.length -1; i++) {
+    if (types[i].typeName  !== 'null') {
+      break;
+    }
+  }
+  return i
+}
 
 module.exports = {
   abstractFunction: abstractFunction,
@@ -901,5 +909,6 @@ module.exports = {
   BufferPool: BufferPool,
   Lcg: Lcg,
   OrderedQueue: OrderedQueue,
-  Tap: Tap
+  Tap: Tap,
+  tryTofindANotNullTypeIndex: tryTofindANonNullTypeIndex
 };

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -2676,6 +2676,7 @@ suite('types', function () {
       assert.deepEqual(t.clone(d), d);
       assert.equal(t.compare(d, d), 0);
       assert.equal(t.getSchema(), 'long');
+      assert(t.isValid(t.sample()));
     });
 
     test('invalid type', function () {

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -2457,6 +2457,10 @@ suite('types', function () {
         assert(slowLongType.isValid(slowLongType.random()));
       });
 
+      test('sample', function () {
+        assert(slowLongType.isValid(slowLongType.sample()));
+      });
+
       test('isValid hook', function () {
         var s = 'hi';
         var errs = [];
@@ -2543,6 +2547,10 @@ suite('types', function () {
 
       test('random', function () {
         assert(slowLongType.isValid(slowLongType.random()));
+      });
+
+      test('sample', function () {
+        assert(slowLongType.isValid(slowLongType.sample()));
       });
 
       test('evolution to/from', function () {
@@ -4117,6 +4125,7 @@ function testType(Type, data, invalidSchemas) {
         // Run a few times to make sure we cover any branches.
         assert(type.isValid(type.random()));
       }
+      assert(type.isValid(type.sample()));
     });
   });
 

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -426,4 +426,37 @@ suite('utils', function () {
     }
   });
 
+  suite('tryTofindANotNullTypeIndex', function () {
+
+    var tryTofindANotNullTypeIndex = utils.tryTofindANotNullTypeIndex
+
+    test('no null types', function() {
+      var result = tryTofindANotNullTypeIndex([
+        { typeName: "boolean" },
+        { typeName: "string" }
+      ]);
+      assert.equal(result, 0)
+    })
+
+    test('skip null types', function() {
+      var result = tryTofindANotNullTypeIndex([
+        { typeName: "null" },
+        { typeName: "string" }
+      ]);
+      assert.equal(result, 1)
+    })
+
+    test('only null type', function() {
+      var result = tryTofindANotNullTypeIndex([
+        { typeName: "null" }
+      ]);
+      assert.equal(result, 0)
+    })
+
+    test('empty array', function() {
+      var result = tryTofindANotNullTypeIndex([]);
+      assert.equal(result, 0)
+    })
+  })
+
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -169,6 +169,7 @@ export class Type {
   inspect(): string;
   isValid(val: any, opts?: Partial<IsValidOptions>): boolean;
   random(): Type;
+  sample(): Type;
   schema(opts?: Partial<SchemaOptions>): Schema;
   toBuffer(value: any): Buffer;
   toJSON(): object;
@@ -307,43 +308,51 @@ export namespace types {
     constructor(schema: Schema, opts: any);
     readonly itemsType: Type;
     random(): ArrayType;
+    sample(): ArrayType;
   }
 
   class BooleanType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): BooleanType;
+    sample(): BooleanType;
   }
 
   class BytesType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): BytesType;
+    sample(): BytesType;
   }
 
   class DoubleType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): DoubleType;
+    sample(): DoubleType;
   }
 
   class EnumType extends Type {
     constructor(schema: Schema, opts?: any);
     readonly symbols: string[];
     random(): EnumType;
+    sample(): EnumType;
   }
 
   class FixedType extends Type {
     constructor(schema: Schema, opts?: any);
     readonly size: number;
     random(): FixedType;
+    sample(): FixedType;
   }
 
   class FloatType extends Type {
     constructor();
     random(): FloatType;
+    sample(): FloatType;
   }
 
   class IntType extends Type {
     constructor();
     random(): IntType;
+    sample(): IntType;
   }
 
   class LogicalType extends Type {
@@ -354,11 +363,13 @@ export namespace types {
     protected _resolve(type: Type): any;
     protected _toValue(any: any): any;
     random(): LogicalType;
+    sample(): LogicalType;
   }
 
   class LongType extends Type {
     constructor();
     random(): LongType;
+    sample(): LongType;
     static __with(methods: object, noUnpack?: boolean): LongType;
   }
 
@@ -366,11 +377,13 @@ export namespace types {
     constructor(schema: Schema, opts?: any);
     readonly valuesType: any;
     random(): MapType;
+    sample(): MapType;
   }
 
   class NullType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): NullType;
+    sample(): NullType;
   }
 
   class RecordType extends Type {
@@ -379,6 +392,7 @@ export namespace types {
     readonly recordConstructor: any;  // TODO: typeof Record once Record interface/class exists
     field(name: string): Field;
     random(): RecordType;
+    sample(): RecordType;
   }
 
   class Field {
@@ -392,17 +406,20 @@ export namespace types {
   class StringType extends Type {  // TODO: Document this on the wiki
     constructor();
     random(): StringType;
+    sample(): StringType;
   }
 
   class UnwrappedUnionType extends Type {
     constructor(schema: Schema, opts: any);
     random(): UnwrappedUnionType;
+    sample(): UnwrappedUnionType;
     readonly types: Type[];
   }
 
   class WrappedUnionType extends Type {
     constructor(schema: Schema, opts: any);
     random(): WrappedUnionType;
+    sample(): WrappedUnionType;
     readonly types: Type[];
   }
 }


### PR DESCRIPTION
Hi and thank you for this nice library !
This pull request adds a `sample()` method to each type which generates a predictive sample value.
It's inspired by the `random()` method but it's more predictable and works better for a schema preview 😄.