### PR TITLE
ForSchemaOptions.typeHook should accept undefined

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -101,7 +101,7 @@ interface ForSchemaOptions {
   namespace: string;
   noAnonymousTypes: boolean;
   registry: { [name: string]: Type };
-  typeHook: (schema: Schema, opts: ForSchemaOptions) => Type;
+  typeHook: (schema: Schema, opts: ForSchemaOptions) => Type | undefined;
   wrapUnions: boolean | 'auto' | 'always' | 'never';
 }
 


### PR DESCRIPTION
Hi, I've started migrating my project from JS to TS and got an error due to the fact that the type declaration for `typeHook` option does not accept returning `undefined` values.

According to https://github.com/mtth/avsc/blob/f69d61cdeddaee7ba16b9126e0bcf8eaf0a77026/lib/types.js#L154, returning `undefined` should be fine: code behaves as if the `typeHook` was not provided for that specific type we are going through.