### PR TITLE
permit zero length fixed type as specified by avro

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1706,7 +1706,7 @@ EnumType.prototype.random = function () {
 /** Avro fixed type. Represented simply as a `Buffer`. */
 function FixedType(schema, opts) {
   Type.call(this, schema, opts);
-  if (schema.size !== (schema.size | 0) || schema.size < 1) {
+  if (schema.size !== (schema.size | 0) || schema.size < 0) {
     throw new Error(f('invalid %s size', this.branchName));
   }
   this.size = schema.size | 0;

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -984,14 +984,14 @@ suite('types', function () {
       }
     ];
 
-    var schemas = [
-      {name: 'Foo', size: 0},
+    var invalidSchemas = [
+      {name: 'Foo', size: NaN},
       {name: 'Foo', size: -2},
       {name: 'Foo'},
       {}
     ];
 
-    testType(builtins.FixedType, data, schemas);
+    testType(builtins.FixedType, data, invalidSchemas);
 
     test('get full name', function () {
       var t = Type.forSchema({
@@ -1019,6 +1019,11 @@ suite('types', function () {
     test('get size', function () {
       var t = Type.forSchema({type: 'fixed', size: 5, name: 'Id'});
       assert.equal(t.getSize(), 5);
+    });
+
+    test('get zero size', function () {
+      var t = Type.forSchema({type: 'fixed', size: 0, name: 'Id'});
+      assert.equal(t.getSize(), 0);
     });
 
     test('resolve', function () {


### PR DESCRIPTION
The Avro spec does not restrict the fixed type to have at least 1 byte of length
in fact: the binary encoding ist designed to omit a zero length field completely
using the schema this allows one to annotate types with static information which doesn not have to travel across the wire