### PR TITLE
Performance improvements to ArrayType.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1924,7 +1924,7 @@ ArrayType.prototype._check = function (val, flags, hook, path) {
     }
     return false;
   }
-
+  var items = this.itemsType;
   var b = true;
   var i, l, j;
   if (hook) {
@@ -1933,14 +1933,14 @@ ArrayType.prototype._check = function (val, flags, hook, path) {
     path.push('');
     for (i = 0, l = val.length; i < l; i++) {
       path[j] = '' + i;
-      if (!this.itemsType._check(val[i], flags, hook, path)) {
+      if (!items._check(val[i], flags, hook, path)) {
         b = false;
       }
     }
     path.pop();
   } else {
     for (i = 0, l = val.length; i < l; i++) {
-      if (!this.itemsType._check(val[i], flags)) {
+      if (!items._check(val[i], flags)) {
         return false;
       }
     }
@@ -1950,21 +1950,25 @@ ArrayType.prototype._check = function (val, flags, hook, path) {
 
 ArrayType.prototype._read = function (tap) {
   var items = this.itemsType;
-  var val = [];
-  var n;
+  var i = 0;
+  var val, n;
   while ((n = tap.readLong())) {
     if (n < 0) {
       n = -n;
       tap.skipLong(); // Skip size.
     }
+    // Optimization. This is faster than pushing to [] initialized array.
+    // We do this only on first batch as there is no fast way to re-reserve array space once created
+    val = val || new Array(n)
     while (n--) {
-      val.push(items._read(tap));
+      val[i++] = items._read(tap);
     }
   }
-  return val;
+  return val || [];
 };
 
 ArrayType.prototype._skip = function (tap) {
+  var items = this.itemsType;
   var len, n;
   while ((n = tap.readLong())) {
     if (n < 0) {
@@ -1972,7 +1976,7 @@ ArrayType.prototype._skip = function (tap) {
       tap.pos += len;
     } else {
       while (n--) {
-        this.itemsType._skip(tap);
+        items._skip(tap);
       }
     }
   }
@@ -1982,13 +1986,13 @@ ArrayType.prototype._write = function (tap, val) {
   if (!Array.isArray(val)) {
     throwInvalidError(val, this);
   }
-
+  var items = this.itemsType;
   var n = val.length;
   var i;
   if (n) {
     tap.writeLong(n);
     for (i = 0; i < n; i++) {
-      this.itemsType._write(tap, val[i]);
+      items._write(tap, val[i]);
     }
   }
   tap.writeLong(0);


### PR DESCRIPTION
We benchmarked this on internal types with arrays of longer lengths and it brought us ~10% improvement on internal benchmarks.
Note: This creates "holey" arrays in V8 but this seems to have negligible performance impact on the array access speed, presumably JIT or CPU learn to default branch in branch prediction

Sample run:

old:
fromBuffer      | toBuffer      | isValid       | (ops/sec)
---------:      | -------:      | ------:       | ---------
19,109,491      | 5,040,556     | 69,815,976    | ArrayInt.avsc
1,137,653       | 892,341       | 64,718,404    | ArrayString.avsc

new:
fromBuffer      | toBuffer      | isValid       | (ops/sec)
---------:      | -------:      | ------:       | ---------
21,969,180      | 5,099,055     | 70,740,014    | ArrayInt.avsc
1,233,871       | 891,253       | 64,479,021    | ArrayString.avsc