### PR TITLE
Callback type: Make value optional, make error nullable

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,7 +71,7 @@ declare namespace schema {
 
 type Schema = Type | schema.AvroSchema;
 
-type Callback<V, Err = any> = (err: Err, value: V) => void;
+type Callback<V, Err = any> = (err: Err | null, value?: V) => void;
 
 
 type Codec = (buffer: Buffer, callback: Callback<Buffer>) => void;


### PR DESCRIPTION
Without this, code like the following will fail to compile with `strictNullChecks` on: 

```ts
import avsc from 'avsc'
import crc32 from 'buffer-crc32'
import snappy from 'snappy'

export const encodeAvro = (schema: avsc.Schema) =>
  new avsc.streams.BlockEncoder(schema, {
    writeHeader: 'auto',
    codec: 'snappy',
    codecs: {
      snappy: (buf, cb) => {
        const checksum = crc32(buf)
        snappy.compress(buf, (err, deflated) => {
          if (err) {
            return cb(err) // <---
          }

          const block = Buffer.alloc(deflated.length + 4)
          deflated.copy(block)
          checksum.copy(block, deflated.length)
          cb(null, block)
        })
      }
    }
  })

```

The compiler will complain that no argument is given for `value` in `cb(err)`.

Example from a callback type in `@types/node` for reference: `type TransformCallback = (error?: Error | null, data?: any) => void;`