### PR TITLE
Fix `extractFileHeader` return type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -149,7 +149,7 @@ export function createBlobEncoder(schema: Schema, opts?: Partial<EncoderOptions>
 export function createBlobDecoder(blob: Blob, opts?: Partial<DecoderOptions>): streams.BlockDecoder;
 export function discoverProtocol(transport: Service.Transport, options: any, callback: Callback<any>): void;
 export function discoverProtocol(transport: Service.Transport, callback: Callback<any>): void;
-export function extractFileHeader(filePath: string, options?: any): void;
+export function extractFileHeader(filePath: string, options?: any): any;
 export function parse(schemaOrProtocolIdl: string, options?: any): any; // TODO protocol literal or Type
 export function readProtocol(protocolIdl: string, options?: Partial<DecoderOptions>): any;
 export function readSchema(schemaIdl: string, options?: Partial<DecoderOptions>): Schema;


### PR DESCRIPTION
`extractFileHeader` returns header but in types description it returns `void`. 
That cause some Type Script errors when the function is used.
<details>
 <summary>Actual `extractFileHeader` behavior code</summary>

```javascript
function extractFileHeader(path, opts) {
  opts = opts || {};

  var decode = opts.decode === undefined ? true : !!opts.decode;
  var size = Math.max(opts.size || 4096, 4);
  var buf = utils.newBuffer(size);
  var fd = fs.openSync(path, 'r');

  try {
    var pos = fs.readSync(fd, buf, 0, size);
    if (pos < 4 || !containers.MAGIC_BYTES.equals(buf.slice(0, 4))) {
      return null;
    }

    var tap = new utils.Tap(buf);
    var header = null;
    do {
      header = containers.HEADER_TYPE._read(tap);
    } while (!isValid());
    if (decode !== false) {
      var meta = header.meta;
      meta['avro.schema'] = JSON.parse(meta['avro.schema'].toString());
      if (meta['avro.codec'] !== undefined) {
        meta['avro.codec'] = meta['avro.codec'].toString();
      }
    }
    return header;
  } finally {
    fs.closeSync(fd);
  }
```

</details>

Result type in `index.d.ts` changed to `any`.