### PR TITLE
Allow empty doc in readProtocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -581,7 +581,7 @@ function Tokenizer(str) {
 Tokenizer.prototype.next = function (opts) {
   var token = {pos: this.pos, id: undefined, val: undefined};
   var javadoc = this._skip(opts && opts.emitJavadoc);
-  if (javadoc) {
+  if (typeof(javadoc) === 'string') {
     token.id = 'javadoc';
     token.val = javadoc;
   } else {
@@ -750,10 +750,10 @@ function extractJavadoc(str) {
     .split('\n').map(function (line, i) {
       return i ? line.replace(/^\s*\*\s?/, '') : line;
     });
-  while (!lines[0]) {
+  while (lines.length > 0 && !lines[0]) {
     lines.shift();
   }
-  while (!lines[lines.length - 1]) {
+  while (lines.length > 0 && !lines[lines.length - 1]) {
     lines.pop();
   }
   return lines.join('\n');

--- a/test/dat/Hello.avdl
+++ b/test/dat/Hello.avdl
@@ -43,6 +43,9 @@ protocol Simple {
     array<@logicalType("date") long> arrayOfDates;
 
     map<boolean> someMap = {"true": true};
+
+    /** */
+    string fieldWithEmptyDoc;
   }
 
   @doc("An error.")

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -80,7 +80,12 @@ suite('specs', function () {
                   type: {type: 'map', values: 'boolean'},
                   name: 'someMap',
                   'default': {'true': true}
-                }
+                },
+                {
+                  doc: '',
+                  type: 'string',
+                  name: 'fieldWithEmptyDoc',
+                },
               ]
             },
             {


### PR DESCRIPTION
Fix issue where readProtocol would get stuck in infinite loop if an schema element has an empty doc

Fixes issue #381