### PR TITLE
Improved number type inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lib/types.js
+++ b/lib/types.js
@@ -55,6 +55,19 @@ var LOGICAL_TYPE = null;
 // to be able to reference names (i.e. for branches) during instantiation.
 var UNDERLYING_TYPES = [];
 
+
+// range of values represented by 32 bit signed int
+const MAX_INT = 2 ** 31 - 1;
+const MIN_INT = 2 ** 31 * -1;
+
+// range of values represented by 64 bit signed int
+const MAX_LONG = 2 ** 63 - 1;
+const MIN_LONG = 2 ** 63 * -1;
+
+// range of values possible to represent by IEEE 754 single precision floating point fraction part
+const MAX_SAFE_FLOAT = 2 ** 23 - 1;
+const MIN_SAFE_FLOAT = -MAX_SAFE_FLOAT;
+
 /**
  * "Abstract" base Avro type.
  *
@@ -252,11 +265,19 @@ Type.forValue = function (val, opts) {
     case 'boolean':
       return Type.forSchema('boolean', opts);
     case 'number':
-      if ((val | 0) === val) {
-        return Type.forSchema('int', opts);
-      } else if (Math.abs(val) < 9007199254740991) {
-        return Type.forSchema('float', opts);
+      if (Number.isInteger(val)) {
+        if (MIN_INT <= val && val <= MAX_INT) {
+          return Type.forSchema('int', opts);  
+        } else if (MIN_LONG <= val && val <= MAX_LONG) {
+          return Type.forSchema('long', opts);
+        }
+      } else {
+        if (MIN_SAFE_FLOAT <= val && val <= MAX_SAFE_FLOAT) {
+          return Type.forSchema('float', opts);
+        }
       }
+      
+      // if all else fails, return double its the broadest type.
       return Type.forSchema('double', opts);
     case 'object':
       if (val === null) {

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -4091,7 +4091,8 @@ suite('types', function () {
     test('numbers', function () {
       assert.equal(infer(1).typeName, 'int');
       assert.equal(infer(1.2).typeName, 'float');
-      assert.equal(infer(9007199254740991).typeName, 'double');
+      assert.equal(infer(9007199254740991).typeName, 'long');
+      assert.equal(infer(2 ** 24 + 0.5).typeName, 'double');
     });
 
     test('function', function () {


### PR DESCRIPTION
I have noticed that the type inference wasn't super strict, this pull request improves on the number type inference as such:

1. Added a test if the given number is a long
2. Made sure float is only returned if its within a safe value (within the fraction part of the float)


This might be useful with more strict type Avro schema checker.