### PR TITLE
Make the "main" property point to the "index.js" file

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lib",
     "types"
   ],
-  "main": "./lib",
+  "main": "./lib/index.js",
   "types": "./types",
   "browser": {
     "./lib": "./etc/browser/avsc.js",


### PR DESCRIPTION
The "main" property of the "package.json" file should point to a "js" file, not to a folder, you can see some examples here: https://github.com/npm/cli/blob/latest/workspaces/arborist/test/arborist/reify.js

I'm surprised nobody complained before, it causes some issues in my projects