### PR TITLE
Refactor import hook API to subsume all platform-dependent behavior

### DIFF
--- a/etc/browser/avsc-services.js
+++ b/etc/browser/avsc-services.js
@@ -7,7 +7,6 @@
  */
 
 let avroTypes = require('./avsc-types'),
-    files = require('../../lib/files'),
     services = require('../../lib/services'),
     specs = require('../../lib/specs'),
     utils = require('../../lib/utils');
@@ -15,7 +14,7 @@ let avroTypes = require('./avsc-types'),
 
 /** Slightly enhanced parsing, supporting IDL declarations. */
 function parse(any, opts) {
-  let schemaOrProtocol = files.readSchemaFromPathOrString(any);
+  let schemaOrProtocol = specs.read(any);
   return schemaOrProtocol.protocol ?
     services.Service.forProtocol(schemaOrProtocol, opts) :
     avroTypes.Type.forSchema(schemaOrProtocol, opts);

--- a/etc/browser/avsc-services.js
+++ b/etc/browser/avsc-services.js
@@ -7,6 +7,7 @@
  */
 
 let avroTypes = require('./avsc-types'),
+    files = require('../../lib/files'),
     services = require('../../lib/services'),
     specs = require('../../lib/specs'),
     utils = require('../../lib/utils');
@@ -14,7 +15,7 @@ let avroTypes = require('./avsc-types'),
 
 /** Slightly enhanced parsing, supporting IDL declarations. */
 function parse(any, opts) {
-  let schemaOrProtocol = specs.read(any);
+  let schemaOrProtocol = files.readSchemaFromPathOrString(any);
   return schemaOrProtocol.protocol ?
     services.Service.forProtocol(schemaOrProtocol, opts) :
     avroTypes.Type.forSchema(schemaOrProtocol, opts);

--- a/etc/browser/lib/files.js
+++ b/etc/browser/lib/files.js
@@ -12,10 +12,12 @@ function createSyncImportHook() {
   return function () { throw createError(); };
 }
 
+function tryReadFileSync() { return null; }
+
 module.exports = {
   createImportHook,
   createSyncImportHook,
   existsSync: function () { return false; },
   readFileSync: function () { throw createError(); },
-  readSchemaFromPathOrString: function () { throw createError(); }
+  tryReadFileSync,
 };

--- a/etc/browser/lib/files.js
+++ b/etc/browser/lib/files.js
@@ -17,7 +17,5 @@ function tryReadFileSync() { return null; }
 module.exports = {
   createImportHook,
   createSyncImportHook,
-  existsSync: function () { return false; },
-  readFileSync: function () { throw createError(); },
   tryReadFileSync,
 };

--- a/etc/browser/lib/files.js
+++ b/etc/browser/lib/files.js
@@ -5,7 +5,7 @@
 function createError() { return new Error('unsupported in the browser'); }
 
 function createImportHook() {
-  return function (fpath, kind, cb) { cb(createError()); };
+  return function (_, cb) { cb(createError()); };
 }
 
 function createSyncImportHook() {

--- a/etc/browser/lib/files.js
+++ b/etc/browser/lib/files.js
@@ -12,10 +12,10 @@ function createSyncImportHook() {
   return function () { throw createError(); };
 }
 
-
 module.exports = {
   createImportHook,
   createSyncImportHook,
   existsSync: function () { return false; },
-  readFileSync: function () { throw createError(); }
+  readFileSync: function () { throw createError(); },
+  readSchemaFromPathOrString: function () { throw createError(); }
 };

--- a/lib/files.js
+++ b/lib/files.js
@@ -8,8 +8,7 @@
  */
 
 let fs = require('fs'),
-    path = require('path'),
-    specs = require('./specs');
+    path = require('path');
 
 /** Default (asynchronous) file loading function for assembling IDLs. */
 function createImportHook() {
@@ -54,68 +53,20 @@ function createSyncImportHook() {
 }
 
 /**
- * Convenience function to parse multiple inputs into protocols and schemas.
- *
- * It should cover most basic use-cases but has a few limitations:
- *
- * + It doesn't allow passing options to the parsing step.
- * + The protocol/type inference logic can be deceived.
- *
- * The parsing logic is as follows:
- *
- * + If `str` contains `path.sep` (on windows `\`, otherwise `/`) and is a path
- *   to an existing file, it will first be read as JSON, then as an IDL
- *   specification if JSON parsing failed. If either succeeds, the result is
- *   returned, otherwise the next steps are run using the file's content
- *   instead of the input path.
- * + If `str` is a valid JSON string, it is parsed then returned.
- * + If `str` is a valid IDL protocol specification, it is parsed and returned
- *   if no imports are present (and an error is thrown if there are any
- *   imports).
- * + If `str` is a valid IDL type specification, it is parsed and returned.
- * + If neither of the above cases apply, `str` is returned.
+ * Check if the given input string is "path-like" or a path to an existing file,
+ * and if so, read it. This requires it to contain a path separator
+ * (`path.sep`). If not, this will return `null`.
  */
-function readSchemaFromPathOrString(str) {
-  let schema;
+function tryReadFileSync(str) {
   if (
     typeof str == 'string' &&
-    str.indexOf('/') !== -1 &&
+    str.indexOf(path.sep) !== -1 &&
     fs.existsSync(str)
   ) {
-    // Try interpreting `str` as path to a file contain a JSON schema or an IDL
-    // protocol. Note that we add the second check to skip primitive references
-    // (e.g. `"int"`, the most common use-case for `avro.parse`).
-    let contents = fs.readFileSync(str, {encoding: 'utf8'});
-    try {
-      return JSON.parse(contents);
-    } catch (err) {
-      let opts = {importHook: createSyncImportHook()};
-      specs.assembleProtocol(str, opts, (err, protocolSchema) => {
-        schema = err ? contents : protocolSchema;
-      });
-    }
-  } else {
-    schema = str;
+    // Try interpreting `str` as path to a file.
+    return fs.readFileSync(str, {encoding: 'utf8'});
   }
-  if (typeof schema != 'string' || schema === 'null') {
-    // This last predicate is to allow `read('null')` to work similarly to
-    // `read('int')` and other primitives (null needs to be handled separately
-    // since it is also a valid JSON identifier).
-    return schema;
-  }
-  try {
-    return JSON.parse(schema);
-  } catch (err) {
-    try {
-      return specs.readProtocol(schema);
-    } catch (err) {
-      try {
-        return specs.readSchema(schema);
-      } catch (err) {
-        return schema;
-      }
-    }
-  }
+  return null;
 }
 
 module.exports = {
@@ -124,5 +75,5 @@ module.exports = {
   // Proxy a few methods to better shim them for browserify.
   existsSync: fs.existsSync,
   readFileSync: fs.readFileSync,
-  readSchemaFromPathOrString
+  tryReadFileSync
 };

--- a/lib/files.js
+++ b/lib/files.js
@@ -13,8 +13,8 @@ let fs = require('fs'),
 /** Default (asynchronous) file loading function for assembling IDLs. */
 function createImportHook() {
   let imports = {};
-  return function ({path: fpath, parentPath}, cb) {
-    fpath = path.resolve(path.dirname(parentPath), fpath);
+  return function ({path: fpath, importerPath}, cb) {
+    fpath = path.resolve(path.dirname(importerPath), fpath);
     if (imports[fpath]) {
       // Already imported, return nothing to avoid duplicating attributes.
       process.nextTick(cb);
@@ -38,8 +38,8 @@ function createImportHook() {
  */
 function createSyncImportHook() {
   let imports = {};
-  return function ({path: fpath, parentPath}, cb) {
-    fpath = path.resolve(path.dirname(parentPath), fpath);
+  return function ({path: fpath, importerPath}, cb) {
+    fpath = path.resolve(path.dirname(importerPath), fpath);
     if (imports[fpath]) {
       cb();
     } else {

--- a/lib/files.js
+++ b/lib/files.js
@@ -76,8 +76,5 @@ function tryReadFileSync(str) {
 module.exports = {
   createImportHook,
   createSyncImportHook,
-  // Proxy a few methods to better shim them for browserify.
-  existsSync: fs.existsSync,
-  readFileSync: fs.readFileSync,
   tryReadFileSync
 };

--- a/lib/files.js
+++ b/lib/files.js
@@ -13,15 +13,18 @@ let fs = require('fs'),
 /** Default (asynchronous) file loading function for assembling IDLs. */
 function createImportHook() {
   let imports = {};
-  return function ({path: fpath}, cb) {
-    fpath = path.resolve(fpath);
+  return function ({path: fpath, parentPath}, cb) {
+    fpath = path.resolve(path.dirname(parentPath), fpath);
     if (imports[fpath]) {
       // Already imported, return nothing to avoid duplicating attributes.
       process.nextTick(cb);
       return;
     }
     imports[fpath] = true;
-    fs.readFile(fpath, {encoding: 'utf8'}, cb);
+    fs.readFile(fpath, {encoding: 'utf8'}, (err, data) => {
+      if (err) return cb(err);
+      return cb(null, {contents: data, path: fpath});
+    });
   };
 }
 
@@ -35,13 +38,16 @@ function createImportHook() {
  */
 function createSyncImportHook() {
   let imports = {};
-  return function ({path: fpath}, cb) {
-    fpath = path.resolve(fpath);
+  return function ({path: fpath, parentPath}, cb) {
+    fpath = path.resolve(path.dirname(parentPath), fpath);
     if (imports[fpath]) {
       cb();
     } else {
       imports[fpath] = true;
-      cb(null, fs.readFileSync(fpath, {encoding: 'utf8'}));
+      cb(null, {
+        contents: fs.readFileSync(fpath, {encoding: 'utf8'}),
+        path: fpath
+      });
     }
   };
 }

--- a/lib/files.js
+++ b/lib/files.js
@@ -13,7 +13,7 @@ let fs = require('fs'),
 /** Default (asynchronous) file loading function for assembling IDLs. */
 function createImportHook() {
   let imports = {};
-  return function (fpath, kind, cb) {
+  return function ({path: fpath}, cb) {
     fpath = path.resolve(fpath);
     if (imports[fpath]) {
       // Already imported, return nothing to avoid duplicating attributes.
@@ -35,7 +35,7 @@ function createImportHook() {
  */
 function createSyncImportHook() {
   let imports = {};
-  return function (fpath, kind, cb) {
+  return function ({path: fpath}, cb) {
     fpath = path.resolve(fpath);
     if (imports[fpath]) {
       cb();

--- a/lib/files.js
+++ b/lib/files.js
@@ -8,7 +8,8 @@
  */
 
 let fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    specs = require('./specs');
 
 /** Default (asynchronous) file loading function for assembling IDLs. */
 function createImportHook() {
@@ -52,11 +53,76 @@ function createSyncImportHook() {
   };
 }
 
+/**
+ * Convenience function to parse multiple inputs into protocols and schemas.
+ *
+ * It should cover most basic use-cases but has a few limitations:
+ *
+ * + It doesn't allow passing options to the parsing step.
+ * + The protocol/type inference logic can be deceived.
+ *
+ * The parsing logic is as follows:
+ *
+ * + If `str` contains `path.sep` (on windows `\`, otherwise `/`) and is a path
+ *   to an existing file, it will first be read as JSON, then as an IDL
+ *   specification if JSON parsing failed. If either succeeds, the result is
+ *   returned, otherwise the next steps are run using the file's content
+ *   instead of the input path.
+ * + If `str` is a valid JSON string, it is parsed then returned.
+ * + If `str` is a valid IDL protocol specification, it is parsed and returned
+ *   if no imports are present (and an error is thrown if there are any
+ *   imports).
+ * + If `str` is a valid IDL type specification, it is parsed and returned.
+ * + If neither of the above cases apply, `str` is returned.
+ */
+function readSchemaFromPathOrString(str) {
+  let schema;
+  if (
+    typeof str == 'string' &&
+    str.indexOf('/') !== -1 &&
+    fs.existsSync(str)
+  ) {
+    // Try interpreting `str` as path to a file contain a JSON schema or an IDL
+    // protocol. Note that we add the second check to skip primitive references
+    // (e.g. `"int"`, the most common use-case for `avro.parse`).
+    let contents = fs.readFileSync(str, {encoding: 'utf8'});
+    try {
+      return JSON.parse(contents);
+    } catch (err) {
+      let opts = {importHook: createSyncImportHook()};
+      specs.assembleProtocol(str, opts, (err, protocolSchema) => {
+        schema = err ? contents : protocolSchema;
+      });
+    }
+  } else {
+    schema = str;
+  }
+  if (typeof schema != 'string' || schema === 'null') {
+    // This last predicate is to allow `read('null')` to work similarly to
+    // `read('int')` and other primitives (null needs to be handled separately
+    // since it is also a valid JSON identifier).
+    return schema;
+  }
+  try {
+    return JSON.parse(schema);
+  } catch (err) {
+    try {
+      return specs.readProtocol(schema);
+    } catch (err) {
+      try {
+        return specs.readSchema(schema);
+      } catch (err) {
+        return schema;
+      }
+    }
+  }
+}
 
 module.exports = {
   createImportHook,
   createSyncImportHook,
   // Proxy a few methods to better shim them for browserify.
   existsSync: fs.existsSync,
-  readFileSync: fs.readFileSync
+  readFileSync: fs.readFileSync,
+  readSchemaFromPathOrString
 };

--- a/lib/files.js
+++ b/lib/files.js
@@ -60,11 +60,15 @@ function createSyncImportHook() {
 function tryReadFileSync(str) {
   if (
     typeof str == 'string' &&
-    str.indexOf(path.sep) !== -1 &&
-    fs.existsSync(str)
+    str.indexOf(path.sep) !== -1
   ) {
-    // Try interpreting `str` as path to a file.
-    return fs.readFileSync(str, {encoding: 'utf8'});
+    try {
+      // Try interpreting `str` as path to a file.
+      return fs.readFileSync(str, {encoding: 'utf8'});
+    } catch (err) {
+      // If the file doesn't exist, return `null`. Rethrow all other errors.
+      if (err.code !== 'ENOENT') throw err;
+    }
   }
   return null;
 }

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -57,19 +57,19 @@ function assembleProtocol(fpath, opts, cb) {
   });
 
   function importFile(fpath, parentPath, cb) {
-    opts.importHook({path: fpath, parentPath, kind: 'idl'}, (err, params) => {
+    opts.importHook({path: fpath, parentPath, kind: 'idl'}, (err, payload) => {
       if (err) {
         cb(err);
         return;
       }
-      if (!params) {
+      if (!payload) {
         // This signals an already imported file by the default import hooks.
         // Implementors who wish to disallow duplicate imports should provide a
         // custom hook which throws an error when a duplicate is detected.
         cb();
         return;
       }
-      const {contents: str, path: fpath} = params;
+      const {contents: str, path: fpath} = payload;
       let obj;
       try {
         let reader = new Reader(str, opts);
@@ -121,7 +121,7 @@ function assembleProtocol(fpath, opts, cb) {
           path: info.name,
           parentPath: fpath,
           kind: info.kind
-        }, (err, params) => {
+        }, (err, payload) => {
           if (err) {
             cb(err);
             return;
@@ -129,16 +129,16 @@ function assembleProtocol(fpath, opts, cb) {
           switch (info.kind) {
             case 'protocol':
             case 'schema': {
-              if (!params) {
+              if (!payload) {
                 // Skip duplicate import (see related comment above).
                 next();
                 return;
               }
               let obj;
               try {
-                obj = JSON.parse(params.contents);
+                obj = JSON.parse(payload.contents);
               } catch (err) {
-                err.path = params.path;
+                err.path = payload.path;
                 cb(err);
                 return;
               }

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -56,8 +56,8 @@ function assembleProtocol(fpath, opts, cb) {
     cb(null, protocol);
   });
 
-  function importFile(fpath, parentPath, cb) {
-    opts.importHook({path: fpath, parentPath, kind: 'idl'}, (err, payload) => {
+  function importFile(fpath, importerPath, cb) {
+    opts.importHook({path: fpath, importerPath, kind: 'idl'}, (err, payload) => {
       if (err) {
         cb(err);
         return;
@@ -119,7 +119,7 @@ function assembleProtocol(fpath, opts, cb) {
         // We are importing a protocol or schema file.
         opts.importHook({
           path: info.name,
-          parentPath: fpath,
+          importerPath: fpath,
           kind: info.kind
         }, (err, payload) => {
           if (err) {

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -31,7 +31,7 @@ function assembleProtocol(fpath, opts, cb) {
     opts.importHook = files.createImportHook();
   }
 
-  importFile(fpath, (err, protocol) => {
+  importFile(fpath, '', (err, protocol) => {
     if (err) {
       cb(err);
       return;
@@ -57,19 +57,20 @@ function assembleProtocol(fpath, opts, cb) {
     cb(null, protocol);
   });
 
-  function importFile(fpath, cb) {
-    opts.importHook({path: fpath, kind: 'idl'}, (err, str) => {
+  function importFile(fpath, parentPath, cb) {
+    opts.importHook({path: fpath, parentPath, kind: 'idl'}, (err, params) => {
       if (err) {
         cb(err);
         return;
       }
-      if (str === undefined) {
+      if (!params) {
         // This signals an already imported file by the default import hooks.
         // Implementors who wish to disallow duplicate imports should provide a
         // custom hook which throws an error when a duplicate is detected.
         cb();
         return;
       }
+      const {contents: str, path: fpath} = params;
       let obj;
       try {
         let reader = new Reader(str, opts);
@@ -79,11 +80,11 @@ function assembleProtocol(fpath, opts, cb) {
         cb(err);
         return;
       }
-      fetchImports(obj.protocol, obj.imports, path.dirname(fpath), cb);
+      fetchImports(obj.protocol, obj.imports, fpath, cb);
     });
   }
 
-  function fetchImports(protocol, imports, dpath, cb) {
+  function fetchImports(protocol, imports, fpath, cb) {
     let importedProtocols = [];
     next();
 
@@ -104,9 +105,8 @@ function assembleProtocol(fpath, opts, cb) {
         cb(null, protocol);
         return;
       }
-      let importPath = path.join(dpath, info.name);
       if (info.kind === 'idl') {
-        importFile(importPath, (err, imported) => {
+        importFile(info.name, fpath, (err, imported) => {
           if (err) {
             cb(err);
             return;
@@ -118,7 +118,11 @@ function assembleProtocol(fpath, opts, cb) {
         });
       } else {
         // We are importing a protocol or schema file.
-        opts.importHook({path: importPath, kind: info.kind}, (err, str) => {
+        opts.importHook({
+          path: info.name,
+          parentPath: fpath,
+          kind: info.kind
+        }, (err, params) => {
           if (err) {
             cb(err);
             return;
@@ -126,16 +130,16 @@ function assembleProtocol(fpath, opts, cb) {
           switch (info.kind) {
             case 'protocol':
             case 'schema': {
-              if (str === undefined) {
+              if (!params) {
                 // Skip duplicate import (see related comment above).
                 next();
                 return;
               }
               let obj;
               try {
-                obj = JSON.parse(str);
+                obj = JSON.parse(params.contents);
               } catch (err) {
-                err.path = importPath;
+                err.path = params.path;
                 cb(err);
                 return;
               }

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -58,7 +58,7 @@ function assembleProtocol(fpath, opts, cb) {
   });
 
   function importFile(fpath, cb) {
-    opts.importHook(fpath, 'idl', (err, str) => {
+    opts.importHook({path: fpath, kind: 'idl'}, (err, str) => {
       if (err) {
         cb(err);
         return;
@@ -118,7 +118,7 @@ function assembleProtocol(fpath, opts, cb) {
         });
       } else {
         // We are importing a protocol or schema file.
-        opts.importHook(importPath, info.kind, (err, str) => {
+        opts.importHook({path: importPath, kind: info.kind}, (err, str) => {
           if (err) {
             cb(err);
             return;

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -7,8 +7,7 @@
 /** IDL to protocol (services) and schema (types) parsing logic. */
 
 let files = require('./files'),
-    utils = require('./utils'),
-    path = require('path');
+    utils = require('./utils');
 
 
 // Default type references defined by Avro.
@@ -197,7 +196,7 @@ function assembleProtocol(fpath, opts, cb) {
  *
  * The parsing logic is as follows:
  *
- * + If `str` contains `path.sep` (on windows `\`, otherwise `/`) and is a path
+ * + If `str` contains `/` and is a path
  *   to an existing file, it will first be read as JSON, then as an IDL
  *   specification if JSON parsing failed. If either succeeds, the result is
  *   returned, otherwise the next steps are run using the file's content
@@ -213,7 +212,7 @@ function read(str) {
   let schema;
   if (
     typeof str == 'string' &&
-    ~str.indexOf(path.sep) &&
+    str.indexOf('/') !== -1 &&
     files.existsSync(str)
   ) {
     // Try interpreting `str` as path to a file contain a JSON schema or an IDL

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -210,15 +210,11 @@ function assembleProtocol(fpath, opts, cb) {
  */
 function read(str) {
   let schema;
-  if (
-    typeof str == 'string' &&
-    str.indexOf('/') !== -1 &&
-    files.existsSync(str)
-  ) {
-    // Try interpreting `str` as path to a file contain a JSON schema or an IDL
-    // protocol. Note that we add the second check to skip primitive references
-    // (e.g. `"int"`, the most common use-case for `avro.parse`).
-    let contents = files.readFileSync(str, {encoding: 'utf8'});
+  let contents = files.tryReadFileSync(str);
+
+  if (contents === null) {
+    schema = str;
+  } else {
     try {
       return JSON.parse(contents);
     } catch (err) {
@@ -227,8 +223,6 @@ function read(str) {
         schema = err ? contents : protocolSchema;
       });
     }
-  } else {
-    schema = str;
   }
   if (typeof schema != 'string' || schema === 'null') {
     // This last predicate is to allow `read('null')` to work similarly to

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -630,8 +630,8 @@ suite('specs', () => {
 
     // Import hook from strings.
     function createImportHook(imports) {
-      return function ({path: fpath, parentPath}, cb) {
-        let key = path.normalize(path.join(path.dirname(parentPath), fpath));
+      return function ({path: fpath, importerPath}, cb) {
+        let key = path.normalize(path.join(path.dirname(importerPath), fpath));
         let str = imports[key];
         delete imports[key];
         process.nextTick(() => { cb(null, typeof str === 'string' ? {

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -451,7 +451,10 @@ suite('specs', () => {
     test('import hook error', (done) => {
       let hook = function ({path: fpath}, cb) {
         if (path.basename(fpath) === 'A.avdl') {
-          cb(null, 'import schema "hi"; protocol A {}');
+          cb(null, {
+            contents: 'import schema "hi"; protocol A {}',
+            path: fpath
+          });
         } else {
           cb(new Error('foo'));
         }
@@ -465,7 +468,10 @@ suite('specs', () => {
     test('import hook idl error', (done) => {
       let hook = function ({path: fpath}, cb) {
         if (path.basename(fpath) === 'A.avdl') {
-          cb(null, 'import idl "hi"; protocol A {}');
+          cb(null, {
+            contents: 'import idl "hi"; protocol A {}',
+            path: fpath
+          });
         } else {
           cb(new Error('bar'));
         }
@@ -624,11 +630,14 @@ suite('specs', () => {
 
     // Import hook from strings.
     function createImportHook(imports) {
-      return function ({path: fpath}, cb) {
-        let key = path.normalize(fpath);
+      return function ({path: fpath, parentPath}, cb) {
+        let key = path.normalize(path.join(path.dirname(parentPath), fpath));
         let str = imports[key];
         delete imports[key];
-        process.nextTick(() => { cb(null, str); });
+        process.nextTick(() => { cb(null, typeof str === 'string' ? {
+          contents: str,
+          path: key
+        } : undefined); });
       };
     }
 

--- a/test/test_specs.js
+++ b/test/test_specs.js
@@ -449,7 +449,7 @@ suite('specs', () => {
     });
 
     test('import hook error', (done) => {
-      let hook = function (fpath, kind, cb) {
+      let hook = function ({path: fpath}, cb) {
         if (path.basename(fpath) === 'A.avdl') {
           cb(null, 'import schema "hi"; protocol A {}');
         } else {
@@ -463,7 +463,7 @@ suite('specs', () => {
     });
 
     test('import hook idl error', (done) => {
-      let hook = function (fpath, kind, cb) {
+      let hook = function ({path: fpath}, cb) {
         if (path.basename(fpath) === 'A.avdl') {
           cb(null, 'import idl "hi"; protocol A {}');
         } else {
@@ -624,7 +624,7 @@ suite('specs', () => {
 
     // Import hook from strings.
     function createImportHook(imports) {
-      return function (fpath, kind, cb) {
+      return function ({path: fpath}, cb) {
         let key = path.normalize(fpath);
         let str = imports[key];
         delete imports[key];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -128,17 +128,17 @@ interface IsValidOptions {
   errorHook: (path: string[], val: any, type: Type) => void
 }
 
-interface ImportHookParams {
+interface ImportHookPayload {
   path: string;
   type: 'idl' | 'protocol' | 'schema';
 }
 
 type ImportHookCallback = (err: any, params?: {contents: string, path: string}) => void;
 
-type ImportHook = (params: ImportHookParams, cb: ImportHookCallback) => void;
+type ImportHook = (payload: ImportHookPayload, cb: ImportHookCallback) => void;
 
 interface AssembleOptions {
-  importHook: (params: ImportHookParams, callback: Callback<object>) => void;
+  importHook: (params: ImportHookPayload, callback: Callback<object>) => void;
 }
 
 interface SchemaOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -127,8 +127,14 @@ interface IsValidOptions {
   noUndeclaredFields: boolean;
   errorHook: (path: string[], val: any, type: Type) => void
 }
+
+interface ImportHookParams {
+  path: string;
+  type: 'idl' | 'protocol' | 'schema';
+}
+
 interface AssembleOptions {
-  importHook: (filePath: string, type: 'idl', callback: Callback<object>) => void;
+  importHook: (params: ImportHookParams, callback: Callback<object>) => void;
 }
 
 interface SchemaOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -133,6 +133,10 @@ interface ImportHookParams {
   type: 'idl' | 'protocol' | 'schema';
 }
 
+type ImportHookCallback = (err: any, params?: {contents: string, path: string}) => void;
+
+type ImportHook = (params: ImportHookParams, cb: ImportHookCallback) => void;
+
 interface AssembleOptions {
   importHook: (params: ImportHookParams, callback: Callback<object>) => void;
 }


### PR DESCRIPTION
First off, apologies for leaving you hanging for a year! Some stuff came up and this fell off my radar for a while, and this seemed like it was going to be more fiddly and difficult than it ended up being.

This import hook API isolates all platform-specific path resolution stuff within the import hook itself. The hook now takes the path of the imported file *and* the path of the file that imported it, and calls the callback with the file contents, and the *resolved* path of the imported file. That second part is what stumped me on my last attempt.

I also started work last year on a "de-Buffer-ification" branch, but ran into some performance cliffs. I finally figured those out (except for TextEncoder/TextDecoder, which is still slower in Node sadly), and the code [is now on GitHub](https://github.com/valadaptive/avsc/tree/debufferify). It's actually *faster* on most benchmarks than the `Buffer` version. It's still a proof-of-concept and will need to be cleaned up. If you're interested in merging it *before* the major version bump, maybe remove `services` first, so I don't have to port that over to use `Uint8Array`.