### PR TITLE
Update slow buffer creation calls (#456)

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -15,11 +15,10 @@
  */
 
 var utils = require('./utils'),
-    buffer = require('buffer'), // For `SlowBuffer`.
+    buffer = require('buffer'),
     util = require('util');
 
 var Buffer = buffer.Buffer;
-var SlowBuffer = buffer.SlowBuffer;
 
 // Convenience imports.
 var Tap = utils.Tap;
@@ -48,7 +47,7 @@ var TYPES = {
 var RANDOM = new utils.Lcg();
 
 // Encoding tap (shared for performance).
-var TAP = new Tap(new SlowBuffer(1024));
+var TAP = new Tap(Buffer.allocUnsafeSlow(1024));
 
 // Currently active logical type, used for name redirection.
 var LOGICAL_TYPE = null;


### PR DESCRIPTION
cherry-picked from bce35cd

Conflicts:
  - ES6 updates (e.g. var -> let)
  - platform lib
  - fully excising 'buffer'