### PR TITLE
fix(types): `forSchema` works with arrays (union)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -189,7 +189,7 @@ export class Type {
   readonly name: string | undefined;
   readonly branchName: string | undefined;
   readonly typeName: string;
-  static forSchema(schema: Schema, opts?: Partial<ForSchemaOptions>): Type;
+  static forSchema(schema: Schema | Schema[], opts?: Partial<ForSchemaOptions>): Type;
   static forTypes(types: Type[], opts?: Partial<TypeOptions>): Type;
   static forValue(value: object, opts?: Partial<ForValueOptions>): Type;
   static isType(arg: any, ...prefix: string[]): boolean;


### PR DESCRIPTION
See https://github.com/mtth/avsc/blob/7cb76a6eb7b0d5b5a71c9cfb446acf3eff763006/lib/types.js#L190