### PR TITLE
feat: allow named types in unions

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1252,28 +1252,44 @@ function generateProjectionIndexer(projectionFn) {
   };
 }
 
-function generateDefaultIndexer() {
-  this._dynamicBranches = null;
-  this._bucketIndices = {};
-  this.types.forEach(function (type, index) {
-    if (Type.isType(type, 'abstract', 'logical')) {
-      if (!this._dynamicBranches) {
-        this._dynamicBranches = [];
+function generateDefaultIndexer(types) {
+  const dynamicBranches = [];
+  const bucketIndices = {};
+
+  const getBranchIndex = (any, index) => {
+    let logicalBranches = dynamicBranches;
+    for (let i = 0, l = logicalBranches.length; i < l; i++) {
+      let branch = logicalBranches[i];
+      if (branch.type._check(any)) {
+        if (index === undefined) {
+          index = branch.index;
+        } else {
+          // More than one branch matches the value so we aren't guaranteed to
+          // infer the correct type. We throw rather than corrupt data. This can
+          // be fixed by "tightening" the logical types.
+          throw new Error('ambiguous conversion');
+        }
       }
-      this._dynamicBranches.push({index, type});
+    }
+    return index;
+  }
+
+  types.forEach(function (type, index) {
+    if (Type.isType(type, 'abstract', 'logical')) {
+      dynamicBranches.push({index, type});
     } else {
       let bucket = getTypeBucket(type);
-      if (this._bucketIndices[bucket] !== undefined) {
+      if (bucketIndices[bucket] !== undefined) {
         throw new Error(`ambiguous unwrapped union: ${j(this)}`);
       }
-      this._bucketIndices[bucket] = index;
+      bucketIndices[bucket] = index;
     }
   }, this);
   return (val) => {
-    let index = this._bucketIndices[getValueBucket(val)];
-    if (this._dynamicBranches) {
+    let index = bucketIndices[getValueBucket(val)];
+    if (dynamicBranches.length) {
       // Slower path, we must run the value through all branches.
-      index = this._getBranchIndex(val, index);
+      index = getBranchIndex(val, index);
     }
     return index;
   };
@@ -1310,28 +1326,10 @@ class UnwrappedUnionType extends UnionType {
       }
     }
     this._getIndex = _projectionFn
-      ? generateProjectionIndexer(projectionFn)
+      ? generateProjectionIndexer(_projectionFn)
       : generateDefaultIndexer.bind(this)(this.types);
 
     Object.freeze(this);
-  }
-
-  _getBranchIndex (any, index) {
-    let logicalBranches = this._dynamicBranches;
-    for (let i = 0, l = logicalBranches.length; i < l; i++) {
-      let branch = logicalBranches[i];
-      if (branch.type._check(any)) {
-        if (index === undefined) {
-          index = branch.index;
-        } else {
-          // More than one branch matches the value so we aren't guaranteed to
-          // infer the correct type. We throw rather than corrupt data. This can
-          // be fixed by "tightening" the logical types.
-          throw new Error('ambiguous conversion');
-        }
-      }
-    }
-    return index;
   }
 
   _check (val, flags, hook, path) {
@@ -1393,16 +1391,18 @@ class UnwrappedUnionType extends UnionType {
           // Using the `coerceBuffers` option can cause corruption and erroneous
           // failures with unwrapped unions (in rare cases when the union also
           // contains a record which matches a buffer's JSON representation).
-          if (isJsonBuffer(val) && this._bucketIndices.buffer !== undefined) {
-            index = this._bucketIndices.buffer;
-          } else {
-            index = this._getIndex(val);
+          if (isJsonBuffer(val)) {
+            let bufIndex = this.types.findIndex(t => getTypeBucket(t) === 'buffer');
+            if (bufIndex !== -1) {
+              index = bufIndex;
+            }
           }
+          index ??= this._getIndex(val);
           break;
         case 2:
           // Decoding from JSON, we must unwrap the value.
           if (val === null) {
-            index = this._bucketIndices['null'];
+            index = this._getIndex(null);
           } else if (typeof val === 'object') {
             let keys = Object.keys(val);
             if (keys.length === 1) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -67,6 +67,7 @@ class Type {
     this.name = undefined;
     this.aliases = undefined;
     this.doc = (schema && schema.doc) ? '' + schema.doc : undefined;
+    this.opts = Object.assign({}, opts);
 
     if (schema) {
       // This is a complex (i.e. non-primitive) type.
@@ -351,7 +352,7 @@ class Type {
     // Group types by category, similar to the logic for unwrapped unions.
     let bucketized = {};
     expanded.forEach((type) => {
-      let bucket = getTypeBucket(type);
+      let bucket = getTypeBucket(type, true);
       let bucketTypes = bucketized[bucket];
       if (!bucketTypes) {
         bucketized[bucket] = bucketTypes = [];
@@ -1258,7 +1259,7 @@ class UnwrappedUnionType extends UnionType {
   }
 
   _getIndex (val) {
-    let index = this._bucketIndices[getValueBucket(val)];
+    let index = this._bucketIndices[getValueBucket(val, this.opts.namespace)];
     if (this._dynamicBranches) {
       // Slower path, we must run the value through all branches.
       index = this._getBranchIndex(val, index);
@@ -3027,8 +3028,9 @@ function maybeQualify(name, ns) {
  * Get a type's bucket when included inside an unwrapped union.
  *
  * @param type {Type} Any type.
+ * @param isExpanded {Boolean} Whether the union is expanded - if yes, we don't use the name to determine the bucket, as the parent type is already in the right bucket.
  */
-function getTypeBucket(type) {
+function getTypeBucket(type, isExpanded) {
   let typeName = type.typeName;
   switch (typeName) {
     case 'double':
@@ -3045,7 +3047,11 @@ function getTypeBucket(type) {
     case 'error':
       return 'object';
     case 'record':
-      return type.name ? maybeQualify(type.name, type.namespace) : 'object';
+      if (isExpanded || !type.name) {
+        return 'object';
+      } else {
+        return maybeQualify(type.name, type.namespace)
+      }
     default:
       return typeName;
   }
@@ -3055,8 +3061,9 @@ function getTypeBucket(type) {
  * Infer a value's bucket (see unwrapped unions for more details).
  *
  * @param val {...} Any value.
+ * @param namespace {String} Optional namespace.
  */
-function getValueBucket(val) {
+function getValueBucket(val, namespace) {
   if (val === null) {
     return 'null';
   }
@@ -3067,6 +3074,12 @@ function getValueBucket(val) {
       return 'array';
     } else if (Buffer.isBuffer(val)) {
       return 'buffer';
+    } else if(typeof val.constructor !== 'undefined' && val.constructor.name) {
+      const isBuiltin = Object.values(module.exports.builtins).some(b => val instanceof b);
+      if (isBuiltin || val.constructor === Object) {
+        return bucket;
+      }
+      return maybeQualify(val.constructor.name, namespace);
     }
   }
   return bucket;

--- a/lib/types.js
+++ b/lib/types.js
@@ -3044,7 +3044,7 @@ function getTypeBucket(type) {
     case 'map':
     case 'error':
     case 'record':
-      return 'object';
+      return type.name ? maybeQualify(type.name, type.namespace) : 'object';
     default:
       return typeName;
   }

--- a/lib/types.js
+++ b/lib/types.js
@@ -3076,9 +3076,8 @@ function getTypeBucket(type) {
       return 'string';
     case 'map':
     case 'error':
-      return 'object';
     case 'record':
-      return type.name ? maybeQualify(type.name, type.namespace) : 'object';
+      return 'object';
     default:
       return typeName;
   }

--- a/lib/types.js
+++ b/lib/types.js
@@ -2987,10 +2987,11 @@ function readArraySize(tap) {
  *
  * + We are not using the `Number` constants for compatibility with older
  *   browsers.
- * + We must remove one from each bound because of rounding errors.
+ * + We divide the bounds by two to avoid rounding errors during zigzag encoding
+ *   (see https://github.com/mtth/avsc/issues/455).
  */
 function isSafeLong(n) {
-  return n >= -9007199254740990 && n <= 9007199254740990;
+  return n >= -4503599627370496 && n <= 4503599627370496;
 }
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -3043,6 +3043,7 @@ function getTypeBucket(type) {
       return 'string';
     case 'map':
     case 'error':
+      return 'object';
     case 'record':
       return type.name ? maybeQualify(type.name, type.namespace) : 'object';
     default:

--- a/lib/types.js
+++ b/lib/types.js
@@ -202,14 +202,10 @@ class Type {
       if (!UnionType) {
         if (typeof opts.wrapUnions === 'function') {
           // we have a projection function
-          try {
-            projectionFn = opts.wrapUnions(types);
-            UnionType = typeof projectionFn !== 'undefined'
-              ? UnwrappedUnionType
-              : WrappedUnionType;
-          } catch(e) {
-            throw new Error(`Error generating projection function: ${e}`);
-          }
+          projectionFn = opts.wrapUnions(types);
+          UnionType = typeof projectionFn !== 'undefined'
+            ? UnwrappedUnionType
+            : WrappedUnionType;
         } else {
           UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
         }
@@ -1319,11 +1315,7 @@ class UnwrappedUnionType extends UnionType {
     super(schema, opts);
 
     if (!_projectionFn && opts && typeof opts.wrapUnions === 'function') {
-      try {
-        _projectionFn = opts.wrapUnions(this.types);
-      } catch(e) {
-        throw new Error(`Error generating projection function: ${e}`);
-      }
+      _projectionFn = opts.wrapUnions(this.types);
     }
     this._getIndex = _projectionFn
       ? generateProjectionIndexer(_projectionFn)

--- a/lib/types.js
+++ b/lib/types.js
@@ -1280,7 +1280,7 @@ function generateDefaultIndexer(types) {
       }
       bucketIndices[bucket] = index;
     }
-  }, this);
+  });
   return (val) => {
     let index = bucketIndices[getValueBucket(val)];
     if (dynamicBranches.length) {
@@ -1319,7 +1319,7 @@ class UnwrappedUnionType extends UnionType {
     }
     this._getIndex = _projectionFn
       ? generateProjectionIndexer(_projectionFn)
-      : generateDefaultIndexer.bind(this)(this.types);
+      : generateDefaultIndexer(this.types);
 
     Object.freeze(this);
   }

--- a/lib/types.js
+++ b/lib/types.js
@@ -1266,13 +1266,31 @@ class UnwrappedUnionType extends UnionType {
 
     this._dynamicBranches = null;
     this._bucketIndices = {};
+
+    this.projectionFunction = (val) => this._bucketIndices[getValueBucket(val)];
+    let hasWrapUnionsFn = opts && typeof opts.wrapUnions === 'function';
+    if (hasWrapUnionsFn) {
+      const projectionFunction = opts.wrapUnions(this.types);
+      if (typeof projectionFunction === 'undefined') {
+        hasWrapUnionsFn = false;
+      } else {
+        this.projectionFunction = (val) => {
+          const index = projectionFunction(val);
+          if (typeof index !== 'number' || index >= this._bucketIndices.length) {
+            throw new Error(`Projected index ${index} is not valid`);
+          }
+          return index;
+        }
+      }
+    }
+
     this.types.forEach(function (type, index) {
       if (Type.isType(type, 'abstract', 'logical')) {
         if (!this._dynamicBranches) {
           this._dynamicBranches = [];
         }
         this._dynamicBranches.push({index, type});
-      } else {
+      } else if (!hasWrapUnionsFn) {
         let bucket = getTypeBucket(type);
         if (this._bucketIndices[bucket] !== undefined) {
           throw new Error(`ambiguous unwrapped union: ${j(this)}`);
@@ -1280,15 +1298,6 @@ class UnwrappedUnionType extends UnionType {
         this._bucketIndices[bucket] = index;
       }
     }, this);
-    this.projectionFunction = opts && typeof opts.wrapUnions === 'function'
-      ? ((fn) => (val) => {
-          const index = fn(val);
-          if (typeof index !== 'number' || index >= this._bucketIndices.length) {
-            throw new Error(`Projected index ${index} is not valid`);
-          }
-          return index;
-        })(opts.wrapUnions(this.types))
-      : (val) => this._bucketIndices[getValueBucket(val)]
 
     Object.freeze(this);
   }

--- a/lib/types.js
+++ b/lib/types.js
@@ -200,13 +200,11 @@ class Type {
       });
       let projectionFn;
       if (!UnionType) {
-        // either automatic detection or we have a projection function
         if (typeof opts.wrapUnions === 'function') {
           // we have a projection function
           try {
             projectionFn = opts.wrapUnions(types);
             UnionType = typeof projectionFn !== 'undefined'
-              // projection function yields a function, we can use an Unwrapped type
               ? UnwrappedUnionType
               : WrappedUnionType;
           } catch(e) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -67,7 +67,6 @@ class Type {
     this.name = undefined;
     this.aliases = undefined;
     this.doc = (schema && schema.doc) ? '' + schema.doc : undefined;
-    this.opts = Object.assign({}, opts);
 
     if (schema) {
       // This is a complex (i.e. non-primitive) type.
@@ -352,7 +351,7 @@ class Type {
     // Group types by category, similar to the logic for unwrapped unions.
     let bucketized = {};
     expanded.forEach((type) => {
-      let bucket = getTypeBucket(type, true);
+      let bucket = getTypeBucket(type);
       let bucketTypes = bucketized[bucket];
       if (!bucketTypes) {
         bucketized[bucket] = bucketTypes = [];
@@ -1271,7 +1270,7 @@ class UnwrappedUnionType extends UnionType {
   }
 
   _getIndex (val) {
-    let index = this._bucketIndices[getValueBucket(val, this.opts.namespace)];
+    let index = this._bucketIndices[getValueBucket(val)];
     if (this._dynamicBranches) {
       // Slower path, we must run the value through all branches.
       index = this._getBranchIndex(val, index);
@@ -3037,9 +3036,8 @@ function maybeQualify(name, ns) {
  * Get a type's bucket when included inside an unwrapped union.
  *
  * @param type {Type} Any type.
- * @param isExpanded {Boolean} Whether the union is expanded - if yes, we don't use the name to determine the bucket, as the parent type is already in the right bucket.
  */
-function getTypeBucket(type, isExpanded) {
+function getTypeBucket(type) {
   let typeName = type.typeName;
   switch (typeName) {
     case 'double':
@@ -3056,11 +3054,7 @@ function getTypeBucket(type, isExpanded) {
     case 'error':
       return 'object';
     case 'record':
-      if (isExpanded || !type.name) {
-        return 'object';
-      } else {
-        return maybeQualify(type.name, type.namespace)
-      }
+      return type.name ? maybeQualify(type.name, type.namespace) : 'object';
     default:
       return typeName;
   }
@@ -3070,9 +3064,8 @@ function getTypeBucket(type, isExpanded) {
  * Infer a value's bucket (see unwrapped unions for more details).
  *
  * @param val {...} Any value.
- * @param namespace {String} Optional namespace.
  */
-function getValueBucket(val, namespace) {
+function getValueBucket(val) {
   if (val === null) {
     return 'null';
   }
@@ -3083,12 +3076,6 @@ function getValueBucket(val, namespace) {
       return 'array';
     } else if (isBufferLike(val)) {
       return 'buffer';
-    } else if(typeof val.constructor !== 'undefined' && val.constructor.name) {
-      const isBuiltin = Object.values(module.exports.builtins).some(b => val instanceof b);
-      if (isBuiltin || val.constructor === Object) {
-        return bucket;
-      }
-      return maybeQualify(val.constructor.name, namespace);
     }
   }
   return bucket;

--- a/lib/types.js
+++ b/lib/types.js
@@ -198,24 +198,26 @@ class Type {
       let types = schema.map((obj) => {
         return Type.forSchema(obj, opts);
       });
+      let projectionFn;
       if (!UnionType) {
         // either automatic detection or we have a projection function
         if (typeof opts.wrapUnions === 'function') {
           // we have a projection function
           try {
-          UnionType = typeof opts.wrapUnions(types) !== 'undefined'
-            // projection function yields a function, we can use an Unwrapped type
-            ? UnwrappedUnionType
-            : WrappedUnionType;
+            projectionFn = opts.wrapUnions(types);
+            UnionType = typeof projectionFn !== 'undefined'
+              // projection function yields a function, we can use an Unwrapped type
+              ? UnwrappedUnionType
+              : WrappedUnionType;
           } catch(e) {
-            throw new Error(`Union projection function errored: ${e}`);
+            throw new Error(`Error generating projection function: ${e}`);
           }
         } else {
           UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
         }
       }
       LOGICAL_TYPE = logicalType;
-      type = new UnionType(types, opts);
+      type = new UnionType(types, opts, projectionFn);
     } else { // New type definition.
       type = (function (typeName) {
         let Type = TYPES[typeName];
@@ -1241,6 +1243,44 @@ UnionType.prototype._branchConstructor = function () {
   throw new Error('unions cannot be directly wrapped');
 };
 
+
+function generateProjectionIndexer(projectionFn) {
+  return (val) => {
+    const index = projectionFn(val);
+    if (typeof index !== 'number') {
+      throw new Error(`Projected index '${index}' is not valid`);
+    }
+    return index;
+  };
+}
+
+function generateDefaultIndexer() {
+  this._dynamicBranches = null;
+  this._bucketIndices = {};
+  this.types.forEach(function (type, index) {
+    if (Type.isType(type, 'abstract', 'logical')) {
+      if (!this._dynamicBranches) {
+        this._dynamicBranches = [];
+      }
+      this._dynamicBranches.push({index, type});
+    } else {
+      let bucket = getTypeBucket(type);
+      if (this._bucketIndices[bucket] !== undefined) {
+        throw new Error(`ambiguous unwrapped union: ${j(this)}`);
+      }
+      this._bucketIndices[bucket] = index;
+    }
+  }, this);
+  return (val) => {
+    let index = this._bucketIndices[getValueBucket(val)];
+    if (this._dynamicBranches) {
+      // Slower path, we must run the value through all branches.
+      index = this._getBranchIndex(val, index);
+    }
+    return index;
+  };
+}
+
 /**
  * "Natural" union type.
  *
@@ -1261,54 +1301,31 @@ UnionType.prototype._branchConstructor = function () {
  * + `map`, `record`
  */
 class UnwrappedUnionType extends UnionType {
-  constructor (schema, opts) {
+  /**
+   *
+   * @param {*} schema
+   * @param {*} opts
+   * @param {Function|undefined} projectionFn The projection function used
+   *                                          to determine the bucket for the
+   *                                          Union. Falls back to generate
+   *                                          from `wrapUnions` parameter
+   *                                          if given.
+   */
+  constructor (schema, opts, projectionFn) {
     super(schema, opts);
 
-    this._dynamicBranches = null;
-    this._bucketIndices = {};
-
-    this.projectionFunction = (val) => this._bucketIndices[getValueBucket(val)];
-    let hasWrapUnionsFn = opts && typeof opts.wrapUnions === 'function';
-    if (hasWrapUnionsFn) {
-      const projectionFunction = opts.wrapUnions(this.types);
-      if (typeof projectionFunction === 'undefined') {
-        hasWrapUnionsFn = false;
-      } else {
-        this.projectionFunction = (val) => {
-          const index = projectionFunction(val);
-          if (typeof index !== 'number' || index >= this._bucketIndices.length) {
-            throw new Error(`Projected index ${index} is not valid`);
-          }
-          return index;
-        }
+    if (!projectionFn && opts && typeof opts.wrapUnions === 'function') {
+      try {
+        projectionFn = opts.wrapUnions(this.types);
+      } catch(e) {
+        throw new Error(`Error generating projection function: ${e}`);
       }
     }
-
-    this.types.forEach(function (type, index) {
-      if (Type.isType(type, 'abstract', 'logical')) {
-        if (!this._dynamicBranches) {
-          this._dynamicBranches = [];
-        }
-        this._dynamicBranches.push({index, type});
-      } else if (!hasWrapUnionsFn) {
-        let bucket = getTypeBucket(type);
-        if (this._bucketIndices[bucket] !== undefined) {
-          throw new Error(`ambiguous unwrapped union: ${j(this)}`);
-        }
-        this._bucketIndices[bucket] = index;
-      }
-    }, this);
+    this._getIndex = projectionFn
+      ? generateProjectionIndexer(projectionFn)
+      : generateDefaultIndexer.bind(this)(this.types);
 
     Object.freeze(this);
-  }
-
-  _getIndex (val) {
-    let index = this.projectionFunction(val);
-    if (this._dynamicBranches) {
-      // Slower path, we must run the value through all branches.
-      index = this._getBranchIndex(val, index);
-    }
-    return index;
   }
 
   _getBranchIndex (any, index) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -1299,27 +1299,17 @@ function generateDefaultIndexer() {
  * + `map`, `record`
  */
 class UnwrappedUnionType extends UnionType {
-  /**
-   *
-   * @param {*} schema
-   * @param {*} opts
-   * @param {Function|undefined} projectionFn The projection function used
-   *                                          to determine the bucket for the
-   *                                          Union. Falls back to generate
-   *                                          from `wrapUnions` parameter
-   *                                          if given.
-   */
-  constructor (schema, opts, projectionFn) {
+  constructor (schema, opts, /* @private parameter */ _projectionFn) {
     super(schema, opts);
 
-    if (!projectionFn && opts && typeof opts.wrapUnions === 'function') {
+    if (!_projectionFn && opts && typeof opts.wrapUnions === 'function') {
       try {
-        projectionFn = opts.wrapUnions(this.types);
+        _projectionFn = opts.wrapUnions(this.types);
       } catch(e) {
         throw new Error(`Error generating projection function: ${e}`);
       }
     }
-    this._getIndex = projectionFn
+    this._getIndex = _projectionFn
       ? generateProjectionIndexer(projectionFn)
       : generateDefaultIndexer.bind(this)(this.types);
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -13,11 +13,7 @@
  */
 
 let utils = require('./utils'),
-    platform = require('./platform'),
-    buffer = require('buffer'); // For `SlowBuffer`.
-
-let Buffer = buffer.Buffer;
-let SlowBuffer = buffer.SlowBuffer;
+    platform = require('./platform');
 
 // Convenience imports.
 let Tap = utils.Tap;
@@ -32,7 +28,7 @@ let TYPES;
 let RANDOM = new utils.Lcg();
 
 // Encoding tap (shared for performance).
-let TAP = new Tap(new SlowBuffer(1024));
+let TAP = new Tap(Buffer.allocUnsafeSlow(1024));
 
 // Currently active logical type, used for name redirection.
 let LOGICAL_TYPE = null;
@@ -443,7 +439,7 @@ class Type {
 
   static __reset (size) {
     debug('resetting type buffer to %d', size);
-    TAP.buf = new SlowBuffer(size);
+    TAP.buf = Buffer.allocUnsafeSlow(size);
   }
 
   get branchName () {

--- a/lib/types.js
+++ b/lib/types.js
@@ -111,6 +111,8 @@ class Type {
         wrapUnions = 'auto';
       } else if (typeof wrapUnions == 'string') {
         wrapUnions = wrapUnions.toLowerCase();
+      } else if (typeof wrapUnions === 'function') {
+        wrapUnions = 'auto';
       }
       switch (wrapUnions) {
         case 'always':
@@ -197,7 +199,20 @@ class Type {
         return Type.forSchema(obj, opts);
       });
       if (!UnionType) {
-        UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
+        // either automatic detection or we have a projection function
+        if (typeof opts.wrapUnions === 'function') {
+          // we have a projection function
+          try {
+          UnionType = typeof opts.wrapUnions(types) !== 'undefined'
+            // projection function yields a function, we can use an Unwrapped type
+            ? UnwrappedUnionType
+            : WrappedUnionType;
+          } catch(e) {
+            throw new Error(`Union projection function errored: ${e}`);
+          }
+        } else {
+          UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
+        }
       }
       LOGICAL_TYPE = logicalType;
       type = new UnionType(types, opts);
@@ -341,10 +356,10 @@ class Type {
           return branchTypes[name];
         }), opts);
       } catch (err) {
-        opts.wrapUnions = wrapUnions;
         throw err;
+      } finally {
+        opts.wrapUnions = wrapUnions;
       }
-      opts.wrapUnions = wrapUnions;
       return unionType;
     }
 
@@ -1265,12 +1280,21 @@ class UnwrappedUnionType extends UnionType {
         this._bucketIndices[bucket] = index;
       }
     }, this);
+    this.projectionFunction = opts && typeof opts.wrapUnions === 'function'
+      ? ((fn) => (val) => {
+          const index = fn(val);
+          if (typeof index !== 'number' || index >= this._bucketIndices.length) {
+            throw new Error(`Projected index ${index} is not valid`);
+          }
+          return index;
+        })(opts.wrapUnions(this.types))
+      : (val) => this._bucketIndices[getValueBucket(val)]
 
     Object.freeze(this);
   }
 
   _getIndex (val) {
-    let index = this._bucketIndices[getValueBucket(val)];
+    let index = this.projectionFunction(val);
     if (this._dynamicBranches) {
       // Slower path, we must run the value through all branches.
       index = this._getBranchIndex(val, index);

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -131,8 +131,8 @@ suite('types', () => {
 
     let data = [
       {
-        valid: [1, -3, 12314, 9007199254740990, 900719925474090],
-        invalid: [null, 'hi', undefined, 9007199254740991, 1.3, 1e67]
+        valid: [1, -3, 12314, 4503599627370496],
+        invalid: [null, 'hi', undefined, 9007199254740990, 1.3, 1e67]
       }
     ];
 
@@ -145,7 +145,7 @@ suite('types', () => {
     test('resolve long > float', () => {
       let t1 = Type.forSchema('long');
       let t2 = Type.forSchema('float');
-      let n = 9007199254740990; // Number.MAX_SAFE_INTEGER - 1
+      let n = 4503599627370496; // Number.MAX_SAFE_INTEGER / 2
       let buf = t1.toBuffer(n);
       let f = t2.fromBuffer(buf, t2.createResolver(t1));
       assert(Math.abs(f - n) / n < 1e-7);

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3546,6 +3546,16 @@ suite('types', () => {
       assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unknown animal/)
     });
 
+    test('union projection with fallback', () => {
+      let t = Type.forSchema({
+        type: 'record',
+        fields: [
+          {name: 'wrapped', type: ['int', 'double' ]}, // Ambiguous.
+        ]
+      }, {wrapUnions: () => undefined });
+      assert(Type.isType(t.field('wrapped').type, 'union:wrapped'));
+    });
+
     test('invalid wrap unions option', () => {
       assert.throws(() => {
         Type.forSchema('string', {wrapUnions: 'FOO'});

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3492,7 +3492,7 @@ suite('types', () => {
       assert(Type.isType(t.field('unwrapped').type, 'union:unwrapped'));
     });
 
-    test.only('union projection', () => {
+    test('union projection', () => {
       const Dog = {
         type: 'record',
         name: 'Dog',

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3518,7 +3518,7 @@ suite('types', () => {
             } else if ('meow' in animal) {
               return 'Cat';
             }
-            throw new Error('Unkown animal');
+            throw new Error('Unknown animal');
           })(animal);
           return types.indexOf(types.find(type => type.name === animalType));
         }
@@ -3537,7 +3537,7 @@ suite('types', () => {
       const Animal = Type.forSchema(animalTypes, { wrapUnions: mockWrapUnions });
       Animal.toBuffer({ meow: '🐈' });
       assert.equal(mockWrapUnions.calls, 2);
-      assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unkown animal/)
+      assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unknown animal/)
     });
 
     test('invalid wrap unions option', () => {

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3549,7 +3549,7 @@ suite('types', () => {
        // Ambiguous, but we have a projection function
       const Animal = Type.forSchema(animalTypes, { wrapUnions: mockWrapUnions });
       Animal.toBuffer({ meow: '🐈' });
-      assert.equal(mockWrapUnions.calls, 2);
+      assert.equal(mockWrapUnions.calls, 1);
       assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unknown animal/)
     });
 

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -3522,7 +3522,9 @@ suite('types', () => {
       };
       const animalTypes = [Dog, Cat];
 
+      let callsToWrapUnions = 0;
       const wrapUnions = (types) => {
+        callsToWrapUnions++;
         assert.deepEqual(types.map(t => t.name), ['Dog', 'Cat']);
         return (animal) => {
           const animalType = ((animal) => {
@@ -3537,19 +3539,10 @@ suite('types', () => {
         }
       };
 
-      // TODO: replace this with a mock when available
-      // currently we're on mocha without sinon
-      function mockWrapUnions() {
-        mockWrapUnions.calls = typeof mockWrapUnions.calls === 'undefined'
-          ? 1
-          : ++mockWrapUnions.calls;
-        return wrapUnions.apply(null, arguments);
-      }
-
        // Ambiguous, but we have a projection function
-      const Animal = Type.forSchema(animalTypes, { wrapUnions: mockWrapUnions });
+      const Animal = Type.forSchema(animalTypes, { wrapUnions });
       Animal.toBuffer({ meow: '🐈' });
-      assert.equal(mockWrapUnions.calls, 1);
+      assert.equal(callsToWrapUnions, 1);
       assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unknown animal/)
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -96,6 +96,15 @@ interface EncoderOptions {
   syncMarker: Buffer;
 }
 
+/**
+ * A projection function that is used when unwrapping unions.
+ * This function is called at schema parsing time on each union with its branches' types.
+ * If it returns a non-null (function) value, that function will be called each time a value's branch needs to be inferred and should return the branch's index.
+ * The index muss be a number between 0 and length-1 of the passed types.
+ * In this case (a branch index) the union will use an unwrapped representation. Otherwise (undefined), the union will be wrapped.
+ */
+type ProjectionFn = (types: ReadonlyArray<Type>) => ((val: unknown) => number) | undefined;
+
 interface ForSchemaOptions {
   assertLogicalTypes: boolean;
   logicalTypes: { [type: string]: new (schema: Schema, opts?: any) => types.LogicalType; };
@@ -104,7 +113,7 @@ interface ForSchemaOptions {
   omitRecordMethods: boolean;
   registry: { [name: string]: Type };
   typeHook: (schema: Schema | string, opts: ForSchemaOptions) => Type | undefined;
-  wrapUnions: boolean | 'auto' | 'always' | 'never';
+  wrapUnions: ProjectionFn | boolean | 'auto' | 'always' | 'never';
 }
 
 interface TypeOptions extends ForSchemaOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,10 +97,14 @@ interface EncoderOptions {
 
 /**
  * A projection function that is used when unwrapping unions.
- * This function is called at schema parsing time on each union with its branches' types.
- * If it returns a non-null (function) value, that function will be called each time a value's branch needs to be inferred and should return the branch's index.
+ * This function is called at schema parsing time on each union with its branches'
+ * types.
+ * If it returns a non-null (function) value, that function will be called each
+ * time a value's branch needs to be inferred and should return the branch's
+ * index.
  * The index muss be a number between 0 and length-1 of the passed types.
- * In this case (a branch index) the union will use an unwrapped representation. Otherwise (undefined), the union will be wrapped.
+ * In this case (a branch index) the union will use an unwrapped representation.
+ * Otherwise (undefined), the union will be wrapped.
  */
 type BranchProjection = (types: ReadonlyArray<Type>) =>
   | ((val: unknown) => number)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,7 +103,9 @@ interface EncoderOptions {
  * The index muss be a number between 0 and length-1 of the passed types.
  * In this case (a branch index) the union will use an unwrapped representation. Otherwise (undefined), the union will be wrapped.
  */
-type ProjectionFn = (types: ReadonlyArray<Type>) => ((val: unknown) => number) | undefined;
+type BranchProjection = (types: ReadonlyArray<Type>) =>
+  | ((val: unknown) => number)
+  | undefined;
 
 interface ForSchemaOptions {
   assertLogicalTypes: boolean;
@@ -113,7 +115,7 @@ interface ForSchemaOptions {
   omitRecordMethods: boolean;
   registry: { [name: string]: Type };
   typeHook: (schema: Schema | string, opts: ForSchemaOptions) => Type | undefined;
-  wrapUnions: ProjectionFn | boolean | 'auto' | 'always' | 'never';
+  wrapUnions: BranchProjection | boolean | 'auto' | 'always' | 'never';
 }
 
 interface TypeOptions extends ForSchemaOptions {


### PR DESCRIPTION
The Avro specification defines:

> Unions may not contain more than one schema with the same type, except for the named types record, fixed and enum

see https://avro.apache.org/docs/1.11.1/specification/#unions

meaning that if a `record` type has a name, it is valid to mix multiple of them in a union, unwrapped.

The same change should possibly be made for enums as well.