### PR TITLE
chore: update node version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - '19'
+          - '22'
+          - '20'
           - '18'
-          - '17'
-          - '16'
-          - '14'
     name: Test using node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Reasoning:
* Current is 22
* Active is 20
* Maintenance is 18

Any odd-numbered releases and older than 18 are unsupported.

We could possibly add 23 if we wanted to be thorough, but sticking to LTS versions is probably okay.

![schedule](https://github.com/user-attachments/assets/947d773d-c973-41df-a0af-988055a79a0c)


From https://nodejs.org/en/about/previous-releases on 2024-09-11.

We should probably also update https://github.com/mtth/avsc/blob/7cb76a6eb7b0d5b5a71c9cfb446acf3eff763006/package.json#L43

Node 6 was released on 26 Apr 2016, over 8 years ago.