### PR TITLE
docs: update decoder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ const avro = require('avsc');
   compressed using [Snappy][snappy]):
 
   ```javascript
-  avro.createFileDecoder('./values.avro')
-    .on('metadata', function (type) { /* `type` is the writer's type. */ })
-    .on('data', function (val) { /* Do something with the decoded value. */ });
+  await new Promise((resolve, reject) => {  
+    avro.createFileDecoder('./values.avro')
+      .on('metadata', function (type) { /* `type` is the writer's type. */ })
+      .on('data', function (val) { /* Do something with the decoded value. */ })
+      .on('end', resolve)
+      .on('error', reject);
+  });
   ```
 
 


### PR DESCRIPTION
The current example won't emit anything as the node script will be finished before the event callbacks are triggered. I updated the example to make that more obvious and easier to copy & paste into an existing project. It also surfaces errors as Promise rejections, the old example didn't attach to the `'error'` event.