### PR TITLE
fix: `typeHook` can receive `string`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,7 +103,7 @@ interface ForSchemaOptions {
   noAnonymousTypes: boolean;
   omitRecordMethods: boolean;
   registry: { [name: string]: Type };
-  typeHook: (schema: Schema, opts: ForSchemaOptions) => Type | undefined;
+  typeHook: (schema: Schema | string, opts: ForSchemaOptions) => Type | undefined;
   wrapUnions: boolean | 'auto' | 'always' | 'never';
 }
 


### PR DESCRIPTION
`typeHook` is called for an unknown named type, e.g. `{ type: "record", name: "ns.MyName" }` yields `typeHook("ns.MyName", ...`

via https://github.com/mtth/avsc/issues/468#issuecomment-2357448344
