### PR TITLE
ci: use checkouts v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - '18'
     name: Test using node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node ${{ matrix.node }}
         shell: bash -eo pipefail -l {0}
         run: |


### PR DESCRIPTION

<img width="1278" alt="Screenshot 2024-09-23 at 12 58 28 PM" src="https://github.com/user-attachments/assets/e51928c6-1c7d-4424-a15f-8339fb4e41e1">


see https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

