### PR TITLE
fix: browser support without bundler/browserify

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,5 +1,5 @@
 let crypto = require('crypto');
-let util = require('util');
+let util = typeof process !== "undefined" ? require('util') : { debuglog: console.log };
 
 /**
  * Compute a string's hash.


### PR DESCRIPTION
Check issue here: https://github.com/browserify/node-util/pull/62

It throws error `process is not defined` if bundler does not handle it when used in browser.