### PR TITLE
fix: process is not defined in browser env

### DIFF
--- a/etc/browser/lib/platform.js
+++ b/etc/browser/lib/platform.js
@@ -24,17 +24,7 @@ function deprecate (fn) {
   return fn;
 }
 
-/**
- * Browser stub for debuglog(). Never does any logging.
- * @returns A function that can be called with log messages. Does nothing with
- * those messages.
- */
-function debuglog () {
-  return () => {};
-}
-
 module.exports = {
   getHash,
   deprecate,
-  debuglog
 };

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,5 +1,4 @@
 let crypto = require('crypto');
-let util = require('util');
 
 /**
  * Compute a string's hash.
@@ -17,5 +16,4 @@ function getHash(str, algorithm) {
 
 module.exports = {
   getHash,
-  debuglog: util.debuglog
 };

--- a/lib/types.js
+++ b/lib/types.js
@@ -172,7 +172,6 @@ class Type {
         try {
           return new DerivedType(schema, opts);
         } catch (err) {
-          console.error('failed to instantiate logical type for %s', schema.logicalType);
           if (opts.assertLogicalTypes) {
             // The spec mandates that we fall through to the underlying type if
             // the logical type is invalid. We provide this option to ease

--- a/lib/types.js
+++ b/lib/types.js
@@ -17,7 +17,6 @@ let utils = require('./utils'),
 
 // Convenience imports.
 let {Tap, isBufferLike} = utils;
-let debug = platform.debuglog('avsc:types');
 let j = utils.printJSON;
 
 // All non-union concrete (i.e. non-logical) Avro types.
@@ -172,10 +171,9 @@ class Type {
           registry[key] = opts.registry[key];
         });
         try {
-          debug('instantiating logical type for %s', schema.logicalType);
           return new DerivedType(schema, opts);
         } catch (err) {
-          debug('failed to instantiate logical type for %s', schema.logicalType);
+          console.error('failed to instantiate logical type for %s', schema.logicalType);
           if (opts.assertLogicalTypes) {
             // The spec mandates that we fall through to the underlying type if
             // the logical type is invalid. We provide this option to ease
@@ -449,7 +447,6 @@ class Type {
   }
 
   static __reset (size) {
-    debug('resetting type buffer to %d', size);
     TAP.reinitialize(size);
   }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -12,8 +12,7 @@
  *
  */
 
-let utils = require('./utils'),
-    platform = require('./platform');
+let utils = require('./utils');
 
 // Convenience imports.
 let {Tap, isBufferLike} = utils;


### PR DESCRIPTION
As discussed #483, `util` package does not support in browser env without proper bundler setup.