### PR TITLE
fix(UnwrappedUnionType): `this` reference

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1243,7 +1243,7 @@ function generateProjectionIndexer(projectionFn) {
   };
 }
 
-function generateDefaultIndexer(types) {
+function generateDefaultIndexer(types, self) {
   const dynamicBranches = [];
   const bucketIndices = {};
 
@@ -1271,7 +1271,7 @@ function generateDefaultIndexer(types) {
     } else {
       let bucket = getTypeBucket(type);
       if (bucketIndices[bucket] !== undefined) {
-        throw new Error(`ambiguous unwrapped union: ${j(this)}`);
+        throw new Error(`ambiguous unwrapped union: ${j(self)}`);
       }
       bucketIndices[bucket] = index;
     }
@@ -1314,7 +1314,7 @@ class UnwrappedUnionType extends UnionType {
     }
     this._getIndex = _projectionFn
       ? generateProjectionIndexer(_projectionFn)
-      : generateDefaultIndexer(this.types);
+      : generateDefaultIndexer(this.types, this);
 
     Object.freeze(this);
   }


### PR DESCRIPTION
Was broken via #469.

Without this fix, the error message is `undefined`:

<img width="972" alt="Screenshot 2024-10-09 at 8 54 26 PM" src="https://github.com/user-attachments/assets/f53e6052-cccd-47e0-a838-e09b038a9b2f">