### PR TITLE
allow extra schema properties for iceberg

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2021,
     impliedStrict: true
   },
   env: {
@@ -36,7 +36,10 @@ module.exports = {
 
         'no-var': ['error'],
         'prefer-arrow-callback': ['error'],
-        'arrow-parens': ['error', 'always']
+        'arrow-parens': ['error', 'always'],
+        'no-unused-vars': ['error', {
+          ignoreRestSiblings: true,
+        }]
       },
     },
     {

--- a/lib/types.js
+++ b/lib/types.js
@@ -93,6 +93,14 @@ class Type {
       this.aliases = schema.aliases ?
         schema.aliases.map((s) => { return maybeQualify(s, namespace); }) :
         [];
+      if (typeof schema === 'object') {
+        const { name, aliases, doc, namespace, type, size, fields,
+          ...other } = schema;
+        delete other.default;
+        if (Object.keys(other).length > 0) {
+          this._extra = other;
+        }
+      }
     }
   }
 
@@ -203,7 +211,9 @@ class Type {
             ? UnwrappedUnionType
             : WrappedUnionType;
         } else {
-          UnionType = isAmbiguous(types) ? WrappedUnionType : UnwrappedUnionType;
+          UnionType = isAmbiguous(types)
+            ? WrappedUnionType
+            : UnwrappedUnionType;
         }
       }
       LOGICAL_TYPE = logicalType;
@@ -347,8 +357,6 @@ class Type {
         unionType = Type.forSchema(Object.keys(branchTypes).map((name) => {
           return branchTypes[name];
         }), opts);
-      } catch (err) {
-        throw err;
       } finally {
         opts.wrapUnions = wrapUnions;
       }
@@ -1263,9 +1271,9 @@ function generateDefaultIndexer(types, self) {
       }
     }
     return index;
-  }
+  };
 
-  types.forEach(function (type, index) {
+  types.forEach((type, index) => {
     if (Type.isType(type, 'abstract', 'logical')) {
       dynamicBranches.push({index, type});
     } else {
@@ -1379,7 +1387,8 @@ class UnwrappedUnionType extends UnionType {
           // failures with unwrapped unions (in rare cases when the union also
           // contains a record which matches a buffer's JSON representation).
           if (isJsonBuffer(val)) {
-            let bufIndex = this.types.findIndex(t => getTypeBucket(t) === 'buffer');
+            let bufIndex = this.types.findIndex((t) =>
+              getTypeBucket(t) === 'buffer');
             if (bufIndex !== -1) {
               index = bufIndex;
             }
@@ -2529,6 +2538,9 @@ class RecordType extends Type {
         if (fieldDoc !== undefined) {
           fieldSchema.doc = fieldDoc;
         }
+        if (field._extra) {
+          Object.assign(fieldSchema, field._extra);
+        }
       }
       return fieldSchema;
     });
@@ -2855,6 +2867,13 @@ class Field {
         this.defaultValue = function () { return val; };
       } else {
         this.defaultValue = function () { return type._copy(val); };
+      }
+    }
+    if (typeof schema === 'object') {
+      const { name, type, doc, aliases, order, size, ...other } = schema;
+      delete other.default;
+      if (Object.keys(other).length > 0) {
+        this._extra = other;
       }
     }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -721,6 +721,11 @@ class Type {
       if (this.doc !== undefined) {
         schema.doc = this.doc;
       }
+      // Export extra properties for non-record types (arrays, maps, etc.)
+      // Record types handle field-level extras in their _deref method
+      if (this._extra && this.typeName !== 'record') {
+        Object.assign(schema, this._extra);
+      }
     }
     return schema;
   }
@@ -1833,6 +1838,12 @@ class MapType extends Type {
     }
     this.valuesType = Type.forSchema(schema.values, opts);
     this._branchConstructor = this._createBranchConstructor();
+    if (typeof schema === 'object') {
+      const { type, values, ...other } = schema;
+      if (Object.keys(other).length > 0) {
+        this._extra = other;
+      }
+    }
     Object.freeze(this);
   }
 
@@ -1968,6 +1979,12 @@ class ArrayType extends Type {
     }
     this.itemsType = Type.forSchema(schema.items, opts);
     this._branchConstructor = this._createBranchConstructor();
+    if (typeof schema === 'object') {
+      const { type, items, ...other } = schema;
+      if (Object.keys(other).length > 0) {
+        this._extra = other;
+      }
+    }
     Object.freeze(this);
   }
 

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -843,7 +843,7 @@ suite('types', () => {
       const roundtripped = type.fromBuffer(type.toBuffer(data));
       assert.equal(roundtripped.constructor.name, name);
       assert.deepEqual(roundtripped, data);
-    })
+    });
   });
 
   suite('EnumType', () => {
@@ -3525,7 +3525,7 @@ suite('types', () => {
       let callsToWrapUnions = 0;
       const wrapUnions = (types) => {
         callsToWrapUnions++;
-        assert.deepEqual(types.map(t => t.name), ['Dog', 'Cat']);
+        assert.deepEqual(types.map((t) => t.name), ['Dog', 'Cat']);
         return (animal) => {
           const animalType = ((animal) => {
             if ('bark' in animal) {
@@ -3535,15 +3535,15 @@ suite('types', () => {
             }
             throw new Error('Unknown animal');
           })(animal);
-          return types.indexOf(types.find(type => type.name === animalType));
-        }
+          return types.indexOf(types.find((type) => type.name === animalType));
+        };
       };
 
-       // Ambiguous, but we have a projection function
+      // Ambiguous, but we have a projection function
       const Animal = Type.forSchema(animalTypes, { wrapUnions });
       Animal.toBuffer({ meow: '🐈' });
       assert.equal(callsToWrapUnions, 1);
-      assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unknown animal/)
+      assert.throws(() => Animal.toBuffer({ snap: '🐊' }), /Unknown animal/);
     });
 
     test('union projection with fallback', () => {


### PR DESCRIPTION
Take extra properties from the schema objects and propagate them to the avro.schema.  Iceberg avro manifests need field-id's for interop.